### PR TITLE
feat(cli): add --stdout option to hf download (#3176)

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -429,6 +429,20 @@ By default, the `hf download` command will be verbose. It will print details suc
 /home/wauplin/.cache/huggingface/hub/models--gpt2/snapshots/11c5a3d5811f50298f278a704980280950aedb10
 ```
 
+### Stream to stdout
+
+If you want to stream the contents of a single file directly to standard output for Unix piping (e.g. to `jq`, `tar`, or `sha256sum`), use the `--stdout` option:
+
+```bash
+>>> hf download gpt2 config.json --stdout | jq .vocab_size
+50257
+```
+
+When `--stdout` is passed, all informational outputs, progress bars, and completion messages are suppressed so that standard output contains only the file content. If the file is already available in the local cache, chunks are streamed directly from disk; otherwise, they are streamed over HTTP without writing to disk. Broken pipe signals (such as piping to `head`) are handled gracefully.
+
+> [!NOTE]
+> `--stdout` can only be used when downloading a single file, and cannot be combined with `--local-dir`, `--dry-run`, `--include`, or `--exclude`.
+
 ### Download timeout
 
 On machines with slow connections, you might encounter timeout issues like this one:

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -1623,6 +1623,7 @@ $ hf download [OPTIONS] REPO_ID [FILENAMES]...
 * `--dry-run / --no-dry-run`: If True, perform a dry run without actually downloading the file.  [default: no-dry-run]
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
 * `--max-workers INTEGER`: Maximum number of workers to use for downloading files. Default is 8.  [default: 8]
+* `--stdout`: Stream downloaded file contents directly to standard output (single file only).
 * `--help`: Show this message and exit.
 
 Examples
@@ -1632,6 +1633,7 @@ Examples
   $ hf download meta-llama/Llama-3.2-1B-Instruct --local-dir ./models/llama
   $ hf download HuggingFaceM4/FineVision art/ --repo-type dataset
   $ hf download hf://datasets/HuggingFaceH4/ultrachat_200k
+  $ hf download meta-llama/Llama-3.2-1B-Instruct config.json --stdout
 
 Learn more
   Use `hf <command> --help` for more information about a command.

--- a/src/huggingface_hub/cli/download.py
+++ b/src/huggingface_hub/cli/download.py
@@ -13,14 +13,24 @@
 # limitations under the License.
 """Contains command to download files from the Hub with the CLI."""
 
+import os
+import sys
 import warnings
 from typing import Annotated
 
 from huggingface_hub import constants
+from huggingface_hub._local_folder import _validate_relative_filename
 from huggingface_hub._snapshot_download import snapshot_download
 from huggingface_hub.errors import CLIError
-from huggingface_hub.file_download import DryRunFileInfo, hf_hub_download
-from huggingface_hub.utils import _format_size, parse_hf_uri
+from huggingface_hub.file_download import DryRunFileInfo, hf_hub_download, hf_hub_url, try_to_load_from_cache
+from huggingface_hub.utils import (
+    _format_size,
+    build_hf_headers,
+    disable_progress_bars,
+    hf_raise_for_status,
+    http_stream_backoff,
+    parse_hf_uri,
+)
 
 from ._cli_utils import RepoIdArg, RepoType, RepoTypeOptionalOpt, RevisionOpt, TokenOpt
 from ._framework import Argument, Option
@@ -34,7 +44,28 @@ DOWNLOAD_EXAMPLES = [
     "hf download meta-llama/Llama-3.2-1B-Instruct --local-dir ./models/llama",
     "hf download HuggingFaceM4/FineVision art/ --repo-type dataset",
     "hf download hf://datasets/HuggingFaceH4/ultrachat_200k",
+    "hf download meta-llama/Llama-3.2-1B-Instruct config.json --stdout",
 ]
+
+
+def _write_stdout_bytes(chunk: bytes) -> None:
+    if sys.stdout is None:
+        return
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is not None:
+        buffer.write(chunk)
+    else:
+        sys.stdout.write(chunk.decode("utf-8", errors="replace"))
+
+
+def _flush_stdout() -> None:
+    if sys.stdout is None:
+        return
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is not None:
+        buffer.flush()
+    else:
+        sys.stdout.flush()
 
 
 def download(
@@ -90,6 +121,13 @@ def download(
             help="Maximum number of workers to use for downloading files. Default is 8.",
         ),
     ] = 8,
+    stdout: Annotated[
+        bool,
+        Option(
+            "--stdout",
+            help="Stream downloaded file contents directly to standard output (single file only).",
+        ),
+    ] = False,
 ) -> None:
     """Download files from the Hub."""
     if local_dir is not None and cache_dir is not None:
@@ -129,14 +167,82 @@ def download(
     else:
         repo_type_str = (repo_type or RepoType.model).value
 
-    def run_download() -> str | DryRunFileInfo | list[DryRunFileInfo]:
-        filenames_list = filenames if filenames is not None else []
+    filenames_list = filenames if filenames is not None else []
 
-        # Separate subfolder patterns (ending with '/') from regular filenames
-        # Subfolders like "art/" are converted to include patterns like "art/**"
-        subfolders = [f for f in filenames_list if f.endswith("/")]
-        subfolder_patterns = [f"{f.rstrip('/')}/**" for f in subfolders]
-        regular_filenames = [f for f in filenames_list if not f.endswith("/")]
+    # Separate subfolder patterns (ending with '/') from regular filenames
+    # Subfolders like "art/" are converted to include patterns like "art/**"
+    subfolders = [f for f in filenames_list if f.endswith("/")]
+    subfolder_patterns = [f"{f.rstrip('/')}/**" for f in subfolders]
+    regular_filenames = [f for f in filenames_list if not f.endswith("/")]
+
+    if stdout:
+        if local_dir is not None:
+            raise CLIError("Cannot use both `--stdout` and `--local-dir` at the same time.")
+        if dry_run:
+            raise CLIError("Cannot use both `--stdout` and `--dry-run` at the same time.")
+        if include is not None and len(include) > 0:
+            raise CLIError("Cannot use both `--stdout` and `--include` at the same time.")
+        if exclude is not None and len(exclude) > 0:
+            raise CLIError("Cannot use both `--stdout` and `--exclude` at the same time.")
+        if (
+            len(regular_filenames) != 1
+            or len(subfolders) > 0
+            or any("*" in f or "?" in f or "[" in f or "]" in f or not f.strip() for f in regular_filenames)
+        ):
+            raise CLIError("`--stdout` can only be used when downloading a single file.")
+
+        filename = regular_filenames[0]
+        try:
+            _validate_relative_filename(filename)
+        except ValueError as err:
+            raise CLIError(str(err)) from err
+
+        chunk_size = 64 * 1024  # 64KB
+        try:
+            with disable_progress_bars():
+                if not force_download:
+                    cached_path = try_to_load_from_cache(
+                        repo_id=repo_id,
+                        filename=filename,
+                        cache_dir=cache_dir,
+                        revision=revision,
+                        repo_type=repo_type_str,
+                    )
+                    if isinstance(cached_path, str) and os.path.isfile(cached_path):
+                        with open(cached_path, "rb") as f:
+                            while chunk := f.read(chunk_size):
+                                _write_stdout_bytes(chunk)
+                        _flush_stdout()
+                        return
+
+                url = hf_hub_url(
+                    repo_id=repo_id,
+                    filename=filename,
+                    repo_type=repo_type_str,
+                    revision=revision,
+                )
+                headers = build_hf_headers(token=token, library_name="huggingface-cli")
+                with http_stream_backoff(
+                    "GET",
+                    url,
+                    headers=headers,
+                    timeout=constants.HF_HUB_DOWNLOAD_TIMEOUT,
+                ) as response:
+                    hf_raise_for_status(response)
+                    for chunk in response.iter_bytes(chunk_size=chunk_size):
+                        _write_stdout_bytes(chunk)
+                _flush_stdout()
+                return
+        except (BrokenPipeError, KeyboardInterrupt):
+            try:
+                devnull = os.open(os.devnull, os.O_WRONLY)
+                os.dup2(devnull, sys.stdout.fileno())
+                os.close(devnull)
+            except Exception:
+                pass
+            sys.exit(0)
+
+    def run_download() -> str | DryRunFileInfo | list[DryRunFileInfo]:
 
         # Error if subfolder patterns are combined with --include/--exclude
         # Guide user to use --include instead of subfolder argument

--- a/tests/test_cli_download.py
+++ b/tests/test_cli_download.py
@@ -1,0 +1,211 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the `hf download` CLI command, including `--stdout` streaming."""
+
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from huggingface_hub import constants
+from huggingface_hub.cli.download import _flush_stdout, _write_stdout_bytes
+from huggingface_hub.cli.hf import app
+from huggingface_hub.errors import CLIError
+from huggingface_hub.utils import SoftTemporaryDirectory
+
+from .testing_constants import DUMMY_MODEL_ID
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestDownloadStdout:
+    def test_download_stdout_cached_file(self, runner: CliRunner) -> None:
+        with SoftTemporaryDirectory() as tmpdir:
+            cached_file = Path(tmpdir) / "config.json"
+            cached_file.write_bytes(b"cached binary data 12345")
+            with (
+                patch(
+                    "huggingface_hub.cli.download.try_to_load_from_cache", return_value=str(cached_file)
+                ) as mock_cache,
+                patch("huggingface_hub.cli.download.http_stream_backoff") as mock_stream,
+            ):
+                result = runner.invoke(app, ["download", DUMMY_MODEL_ID, "config.json", "--stdout"])
+
+        assert result.exit_code == 0
+        assert result.stdout_bytes == b"cached binary data 12345"
+        mock_cache.assert_called_once()
+        mock_stream.assert_not_called()
+
+    def test_download_stdout_remote_file(self, runner: CliRunner) -> None:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.iter_bytes.return_value = [b"chunk1_", b"chunk2"]
+        mock_cm = Mock()
+        mock_cm.__enter__ = Mock(return_value=mock_response)
+        mock_cm.__exit__ = Mock(return_value=None)
+
+        with (
+            patch("huggingface_hub.cli.download.try_to_load_from_cache", return_value=None) as mock_cache,
+            patch("huggingface_hub.cli.download.http_stream_backoff", return_value=mock_cm) as mock_stream,
+            patch("huggingface_hub.cli.download.hf_raise_for_status") as mock_raise,
+        ):
+            result = runner.invoke(app, ["download", DUMMY_MODEL_ID, "config.json", "--stdout"])
+
+        assert result.exit_code == 0
+        assert result.stdout_bytes == b"chunk1_chunk2"
+        mock_cache.assert_called_once()
+        mock_stream.assert_called_once()
+        assert mock_stream.call_args.kwargs.get("timeout") == constants.HF_HUB_DOWNLOAD_TIMEOUT
+        mock_raise.assert_called_once_with(mock_response)
+
+    def test_download_stdout_force_download_bypasses_cache(self, runner: CliRunner) -> None:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.iter_bytes.return_value = [b"fresh_content"]
+        mock_cm = Mock()
+        mock_cm.__enter__ = Mock(return_value=mock_response)
+        mock_cm.__exit__ = Mock(return_value=None)
+
+        with (
+            patch("huggingface_hub.cli.download.try_to_load_from_cache") as mock_cache,
+            patch("huggingface_hub.cli.download.http_stream_backoff", return_value=mock_cm) as mock_stream,
+        ):
+            result = runner.invoke(app, ["download", DUMMY_MODEL_ID, "config.json", "--stdout", "--force-download"])
+
+        assert result.exit_code == 0
+        assert result.stdout_bytes == b"fresh_content"
+        mock_cache.assert_not_called()
+        mock_stream.assert_called_once()
+
+    def test_download_stdout_hf_uri(self, runner: CliRunner) -> None:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.iter_bytes.return_value = [b"uri_data"]
+        mock_cm = Mock()
+        mock_cm.__enter__ = Mock(return_value=mock_response)
+        mock_cm.__exit__ = Mock(return_value=None)
+
+        with (
+            patch("huggingface_hub.cli.download.try_to_load_from_cache", return_value=None),
+            patch("huggingface_hub.cli.download.http_stream_backoff", return_value=mock_cm) as mock_stream,
+        ):
+            result = runner.invoke(
+                app, ["download", "hf://datasets/author/dataset@refs/pr/3/data/train.csv", "--stdout"]
+            )
+
+        assert result.exit_code == 0
+        assert result.stdout_bytes == b"uri_data"
+        assert "datasets/author/dataset/resolve/refs%2Fpr%2F3/data/train.csv" in mock_stream.call_args[0][1]
+
+    def test_download_stdout_rejects_multiple_files(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["download", DUMMY_MODEL_ID, "file1.txt", "file2.txt", "--stdout"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, CLIError)
+        assert "`--stdout` can only be used when downloading a single file." in str(result.exception)
+
+    def test_download_stdout_rejects_no_files(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["download", DUMMY_MODEL_ID, "--stdout"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, CLIError)
+        assert "`--stdout` can only be used when downloading a single file." in str(result.exception)
+
+    def test_download_stdout_rejects_subfolder(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["download", DUMMY_MODEL_ID, "art/", "--stdout"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, CLIError)
+        assert "`--stdout` can only be used when downloading a single file." in str(result.exception)
+
+    def test_download_stdout_rejects_wildcard(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["download", DUMMY_MODEL_ID, "*.json", "--stdout"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, CLIError)
+        assert "`--stdout` can only be used when downloading a single file." in str(result.exception)
+
+    def test_download_stdout_rejects_bracket_wildcard(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["download", DUMMY_MODEL_ID, "model-[0-9].bin", "--stdout"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, CLIError)
+        assert "`--stdout` can only be used when downloading a single file." in str(result.exception)
+
+    def test_download_stdout_rejects_path_traversal(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["download", DUMMY_MODEL_ID, "../secret.txt", "--stdout"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, CLIError)
+        assert "cannot contain a '..' path segment" in str(result.exception)
+
+    def test_download_stdout_rejects_hf_uri_subfolder(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["download", "hf://datasets/author/dataset/data/", "--stdout"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, CLIError)
+        assert "`--stdout` can only be used when downloading a single file." in str(result.exception)
+
+    def test_download_stdout_rejects_local_dir(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["download", DUMMY_MODEL_ID, "config.json", "--stdout", "--local-dir", "./dir"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, CLIError)
+        assert "Cannot use both `--stdout` and `--local-dir`" in str(result.exception)
+
+    def test_download_stdout_rejects_dry_run(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["download", DUMMY_MODEL_ID, "config.json", "--stdout", "--dry-run"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, CLIError)
+        assert "Cannot use both `--stdout` and `--dry-run`" in str(result.exception)
+
+    def test_download_stdout_rejects_include(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["download", DUMMY_MODEL_ID, "config.json", "--stdout", "--include", "*.json"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, CLIError)
+        assert "Cannot use both `--stdout` and `--include`" in str(result.exception)
+
+    def test_download_stdout_rejects_exclude(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["download", DUMMY_MODEL_ID, "config.json", "--stdout", "--exclude", "*.bin"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, CLIError)
+        assert "Cannot use both `--stdout` and `--exclude`" in str(result.exception)
+
+    def test_download_stdout_broken_pipe_handled_cleanly(self, runner: CliRunner) -> None:
+        with SoftTemporaryDirectory() as tmpdir:
+            cached_file = Path(tmpdir) / "config.json"
+            cached_file.write_bytes(b"cached content")
+            with (
+                patch("huggingface_hub.cli.download.try_to_load_from_cache", return_value=str(cached_file)),
+                patch("huggingface_hub.cli.download._write_stdout_bytes", side_effect=BrokenPipeError("Broken pipe")),
+            ):
+                result = runner.invoke(app, ["download", DUMMY_MODEL_ID, "config.json", "--stdout"])
+
+        assert result.exit_code == 0
+        assert result.exception is None
+
+    def test_download_stdout_keyboard_interrupt_handled_cleanly(self, runner: CliRunner) -> None:
+        with SoftTemporaryDirectory() as tmpdir:
+            cached_file = Path(tmpdir) / "config.json"
+            cached_file.write_bytes(b"cached content")
+            with (
+                patch("huggingface_hub.cli.download.try_to_load_from_cache", return_value=str(cached_file)),
+                patch("huggingface_hub.cli.download._write_stdout_bytes", side_effect=KeyboardInterrupt()),
+            ):
+                result = runner.invoke(app, ["download", DUMMY_MODEL_ID, "config.json", "--stdout"])
+
+        assert result.exit_code == 0
+        assert result.exception is None
+
+    def test_download_stdout_none_stdout_safety(self) -> None:
+        with patch.object(sys, "stdout", None):
+            _write_stdout_bytes(b"some bytes")
+            _flush_stdout()


### PR DESCRIPTION
Fixes #3176

### Motivation
Per feature request by @rwightman in #3176, users often need to stream file bytes directly to standard output for Unix piping (e.g. \hf download <repo> <file> --stdout | jq\, \| tar -x\, \| sha256sum\, or streaming directly into dataset loaders like webdataset) similar to \curl\ / \wget\ transfers.

### Changes
1. **CLI option**: Added \--stdout\ option to \hf download\ in \src/huggingface_hub/cli/download.py\.
2. **Cache-first throughput**: If the file already exists in local cache (\	ry_to_load_from_cache\), chunks are streamed directly from disk instead of issuing redundant network requests.
3. **HTTP streaming with timeout**: If uncached (or \orce_download=True\), chunks are streamed over HTTP via \http_stream_backoff\ with \	imeout=constants.HF_HUB_DOWNLOAD_TIMEOUT\ directly to standard output without intermediate disk writes.
4. **Zero stdout contamination**: Suppressed progress bars (\disable_progress_bars()\) and summary messages (\_print_result\) so stdout contains only pure file bytes.
5. **Defensive pipe lifecycle**: Caught \(BrokenPipeError, KeyboardInterrupt)\ with clean descriptor closure to ensure clean exit (code 0) without tracebacks when downstream utilities (e.g. \head\) close pipes early.
6. **Strict validation & path safety**: Enforced single-file constraint (rejecting multiple files, subfolders, glob patterns, brackets, or empty strings), path safety (\_validate_relative_filename\ rejecting \..\ traversal / UNC paths), and incompatible options (\--local-dir\, \--dry-run\, \--include\, \--exclude\).
7. **Documentation & references**: Added \### Stream to stdout\ section in \docs/source/en/guides/cli.md\ and synchronized \docs/source/en/package_reference/cli.md\ via \utils/generate_cli_reference.py\.
8. **Tests**: Added comprehensive tests in \	ests/test_cli_download.py\ under \TestDownloadStdout\ (18 tests) covering cached, remote, force-download, \hf://\ URI, constraint violations, path traversal rejection, timeout propagation, and broken pipe scenarios.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated CLI download path with strict single-file validation; no changes to core library download APIs beyond reusing existing HTTP/cache helpers.
> 
> **Overview**
> Adds **`--stdout`** to **`hf download`** so a single Hub file can be streamed to standard output for Unix pipes (`jq`, `tar`, checksum tools, etc.), similar to curl/wget-style workflows.
> 
> The implementation prefers the local cache when available (chunked read from disk) and otherwise streams over HTTP via **`http_stream_backoff`** without writing to disk, with progress bars and other CLI noise suppressed so stdout stays raw bytes. **`--force-download`** skips the cache path. Usage is restricted to exactly one concrete file (no globs, subfolders, or multi-file downloads) and is incompatible with **`--local-dir`**, **`--dry-run`**, **`--include`**, and **`--exclude`**; relative paths are validated to block traversal. **`BrokenPipeError`** and **`KeyboardInterrupt`** exit cleanly (code 0) for early pipe closes.
> 
> User-facing docs gain a **Stream to stdout** section in the CLI guide and the package reference is updated. New tests in **`tests/test_cli_download.py`** cover cache vs remote streaming, **`hf://`** URIs, validation errors, and pipe/interrupt handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0eb7c23647c28749e897f982b19c771b09ceb99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->