### PR TITLE
Fix dotenv parser truncating unquoted values containing '#'

### DIFF
--- a/src/huggingface_hub/utils/_dotenv.py
+++ b/src/huggingface_hub/utils/_dotenv.py
@@ -34,10 +34,10 @@ def load_dotenv(dotenv_str: str, environ: dict[str, str] | None = None) -> dict[
             (?:
                 '(?:\\'|[^'])*'           # single-quoted value
                 | \"(?:\\\"|[^\"])*\"     # double-quoted value
-                | [^#\n\r]+?              # unquoted value
+                | [^\n\r]*?               # unquoted value (may contain '#')
             )
         )?
-        [^\S\n]*(?:\#.*)?$                # optional inline comment
+        (?:[^\S\n]+\#[^\n\r]*)?$          # optional inline comment (must be preceded by whitespace)
     """,
         re.VERBOSE,
     )

--- a/src/huggingface_hub/utils/_dotenv.py
+++ b/src/huggingface_hub/utils/_dotenv.py
@@ -29,15 +29,24 @@ def load_dotenv(dotenv_str: str, environ: dict[str, str] | None = None) -> dict[
         ^\s*
         (?:export[^\S\n]+)?               # optional export
         ([A-Za-z_][A-Za-z0-9_]*)          # key
-        [^\S\n]*(=)?[^\S\n]*
-        (                                 # value group
+        [^\S\n]*
+        (?:
+            (=)                           # equal sign
             (?:
-                '(?:\\'|[^'])*'           # single-quoted value
-                | \"(?:\\\"|[^\"])*\"     # double-quoted value
-                | [^\n\r]*?               # unquoted value (may contain '#')
+                [^\S\n]*
+                (                         # quoted value
+                    '(?:\\'|[^'])*'       # single-quoted
+                    | \"(?:\\\"|[^\"])*\" # double-quoted
+                )
+                [^\S\n]*(?:\#[^\n\r]*)?   # inline comment (needs no preceding whitespace after a quote)
+                |
+                (?:[^\S\n]+(?!\#))?       # whitespace after '=' also separates an inline comment
+                (                         # unquoted value (may contain '#')
+                    [^\n\r]*?
+                )
+                (?:[^\S\n]+\#[^\n\r]*)?   # inline comment (must be preceded by whitespace)
             )
-        )?
-        (?:[^\S\n]+\#[^\n\r]*)?$          # optional inline comment (must be preceded by whitespace)
+        )?$
     """,
         re.VERBOSE,
     )
@@ -52,7 +61,7 @@ def load_dotenv(dotenv_str: str, environ: dict[str, str] | None = None) -> dict[
             key = match.group(1)
             val = None
             if match.group(2):  # if there is '='
-                raw_val = match.group(3) or ""
+                raw_val = match.group(3) or match.group(4) or ""
                 val = raw_val.strip()
                 # Remove surrounding quotes if quoted
                 if val.startswith('"') and val.endswith('"'):

--- a/src/huggingface_hub/utils/_dotenv.py
+++ b/src/huggingface_hub/utils/_dotenv.py
@@ -47,7 +47,7 @@ def load_dotenv(dotenv_str: str, environ: dict[str, str] | None = None) -> dict[
                 (?:[^\S\n]+\#[^\n\r]*)?   # inline comment (must be preceded by whitespace)
             )
             |
-            [^\n\r]*                      # bare key (no '='): trailing text/comment is ignored
+            [^\S\n]*(?:\#[^\n\r]*)?       # bare key (no '='), with an optional inline comment
         )$
     """,
         re.VERBOSE,

--- a/src/huggingface_hub/utils/_dotenv.py
+++ b/src/huggingface_hub/utils/_dotenv.py
@@ -29,8 +29,8 @@ def load_dotenv(dotenv_str: str, environ: dict[str, str] | None = None) -> dict[
         ^\s*
         (?:export[^\S\n]+)?               # optional export
         ([A-Za-z_][A-Za-z0-9_]*)          # key
-        [^\S\n]*
         (?:
+            [^\S\n]*
             (=)                           # equal sign
             (?:
                 [^\S\n]*
@@ -46,7 +46,9 @@ def load_dotenv(dotenv_str: str, environ: dict[str, str] | None = None) -> dict[
                 )
                 (?:[^\S\n]+\#[^\n\r]*)?   # inline comment (must be preceded by whitespace)
             )
-        )?$
+            |
+            [^\n\r]*                      # bare key (no '='): trailing text/comment is ignored
+        )$
     """,
         re.VERBOSE,
     )

--- a/tests/test_utils_dotenv.py
+++ b/tests/test_utils_dotenv.py
@@ -107,3 +107,22 @@ def test_single_quoted_values_are_literal():
         "ESCAPED_QUOTE": r"a\"b",
     }
     assert load_dotenv(r'DQ="line1\nline2"') == {"DQ": "line1\nline2"}
+
+
+def test_hash_in_unquoted_value_is_kept():
+    # A "#" only starts an inline comment when preceded by whitespace. A "#" that is part of an
+    # unquoted value (e.g. in a password, token or URL fragment) must be preserved, not truncated.
+    data = """
+    PASSWORD=p@ss#word
+    TOKEN=abc#123
+    URL=http://example.com/x#frag
+    LEADING=#notacomment
+    COMMENTED=value  # actual comment
+    """
+    assert load_dotenv(data) == {
+        "PASSWORD": "p@ss#word",
+        "TOKEN": "abc#123",
+        "URL": "http://example.com/x#frag",
+        "LEADING": "#notacomment",
+        "COMMENTED": "value",
+    }

--- a/tests/test_utils_dotenv.py
+++ b/tests/test_utils_dotenv.py
@@ -126,3 +126,36 @@ def test_hash_in_unquoted_value_is_kept():
         "LEADING": "#notacomment",
         "COMMENTED": "value",
     }
+
+
+def test_empty_value_with_inline_comment():
+    # Whitespace right after "=" also separates an inline comment: the value is empty, not the
+    # comment text. Otherwise a comment would leak into env vars/secrets (e.g. `hf jobs --env-file`).
+    data = """
+    EMPTY= # comment
+    EMPTY_MULTI_SPACE=   # comment
+    EMPTY_NO_COMMENT=
+    LEADING=#notacomment
+    """
+    assert load_dotenv(data) == {
+        "EMPTY": "",
+        "EMPTY_MULTI_SPACE": "",
+        "EMPTY_NO_COMMENT": "",
+        "LEADING": "#notacomment",
+    }
+
+
+def test_comment_attached_to_closing_quote():
+    # After a closing quote, a "#" starts a comment even without preceding whitespace.
+    data = """
+    DQ="value"# comment
+    SQ='value'#comment
+    SPACED="value" # comment
+    HASH_INSIDE="a#b"
+    """
+    assert load_dotenv(data) == {
+        "DQ": "value",
+        "SQ": "value",
+        "SPACED": "value",
+        "HASH_INSIDE": "a#b",
+    }

--- a/tests/test_utils_dotenv.py
+++ b/tests/test_utils_dotenv.py
@@ -171,3 +171,14 @@ def test_bare_key_with_inline_comment():
     """
     environ = {"BARE": "1", "BARE_NO_SPACE": "2", "BARE_PLAIN": "3"}
     assert load_dotenv(data, environ=environ) == {"BARE": "1", "BARE_NO_SPACE": "2", "BARE_PLAIN": "3"}
+
+
+def test_invalid_line_does_not_import_from_environ():
+    # A key followed by arbitrary text is not a valid line: it must be ignored rather than treated
+    # as a bare key, which would pull the host value in and clobber an explicit assignment above.
+    data = """
+    SECRET=explicit_value
+    SECRET is documented above
+    OTHER not an assignment
+    """
+    assert load_dotenv(data, environ={"SECRET": "HOST_ENV", "OTHER": "HOST_ENV"}) == {"SECRET": "explicit_value"}

--- a/tests/test_utils_dotenv.py
+++ b/tests/test_utils_dotenv.py
@@ -159,3 +159,15 @@ def test_comment_attached_to_closing_quote():
         "SPACED": "value",
         "HASH_INSIDE": "a#b",
     }
+
+
+def test_bare_key_with_inline_comment():
+    # A bare key (no "=") is resolved from the environment. A trailing comment must not prevent the
+    # line from matching, otherwise the key is silently dropped by `--env-file` / `--secrets-file`.
+    data = """
+    BARE # comment
+    BARE_NO_SPACE#comment
+    BARE_PLAIN
+    """
+    environ = {"BARE": "1", "BARE_NO_SPACE": "2", "BARE_PLAIN": "3"}
+    assert load_dotenv(data, environ=environ) == {"BARE": "1", "BARE_NO_SPACE": "2", "BARE_PLAIN": "3"}


### PR DESCRIPTION
## Summary

- `load_dotenv` (in `utils/_dotenv.py`, used by `hf jobs --env` / `--env-file`) treats *any* `#` in an unquoted value as the start of an inline comment, so it silently truncates the value.
- By the usual dotenv convention (and `python-dotenv`), a `#` only starts an inline comment when it's **preceded by whitespace**. A `#` that's part of the value — common in passwords, tokens and URL fragments — should be kept.
- This makes unquoted values consistent with quoted ones (which already keep `#`) and with the whitespace-delimited comments the existing tests assume.

## Before / after

```python
from huggingface_hub.utils._dotenv import load_dotenv

# before my PR
load_dotenv("PASSWORD=p@ss#word")             # {'PASSWORD': 'p@ss'}      <- truncated
load_dotenv("TOKEN=abc#123")                  # {'TOKEN': 'abc'}          <- truncated
load_dotenv("URL=http://example.com/x#frag")  # {'URL': 'http://example.com/x'}

# after my PR
load_dotenv("PASSWORD=p@ss#word")             # {'PASSWORD': 'p@ss#word'}
load_dotenv("TOKEN=abc#123")                  # {'TOKEN': 'abc#123'}
load_dotenv("URL=http://example.com/x#frag")  # {'URL': 'http://example.com/x#frag'}
load_dotenv("KEY=value  # real comment")      # {'KEY': 'value'}          <- unchanged
```

## Fix

In the `line_pattern` regex, the unquoted-value branch now allows `#` (`[^#\n\r]+?` → `[^\n\r]*?`), and the inline comment must be preceded by horizontal whitespace (`[^\S\n]*(?:\#.*)?$` → `(?:[^\S\n]+\#[^\n\r]*)?$`). Quoted values and bare keys keep their own trailing-comment branch, since after a closing quote (or a bare key) a `#` starts a comment even with no whitespace in front of it.

No behaviour change for quoted values, whitespace-separated comments, `export`, empty values, or bare keys.

## One more behaviour change

Splitting the regex into explicit "assignment" / "bare key" branches also fixed a second bug: a line that is neither of those used to match as a bare key, pull the host value in, and clobber an explicit assignment above it. It is now simply ignored:

```python
load_dotenv("SECRET=explicit\nSECRET is documented above", environ={"SECRET": "HOST_ENV"})
# before: {'SECRET': 'HOST_ENV'}  <- explicit value overwritten by the host env
# after:  {'SECRET': 'explicit'}
```

## Notes

- One intentional divergence from `python-dotenv`: for `KEY= # comment` it returns `'# comment'`, while this PR keeps the current `huggingface_hub` behaviour and returns `''` — whitespace right after `=` separates an inline comment here too. A leaked comment silently becoming a job env var or secret seems clearly worse than the small inconsistency.
- Because of the above, an unquoted value still can't contain ` #` (whitespace + hash); quote it if you need that.

Added `test_hash_in_unquoted_value_is_kept` for the fix, plus `test_empty_value_with_inline_comment`, `test_comment_attached_to_closing_quote`, `test_bare_key_with_inline_comment` and `test_invalid_line_does_not_import_from_environ` to pin down the surrounding cases the new regex has to keep working. All existing `tests/test_utils_dotenv.py` still pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how env/secrets files are parsed for CLI jobs; fixes incorrect truncation but alters values for any `.env` lines that relied on the old `#`-anywhere comment rule.
> 
> **Overview**
> Fixes **`load_dotenv`** (used by **`hf jobs --env-file` / `--secrets-file`**) so unquoted values are no longer cut off at the first **`#`**. Inline comments now follow the usual rule: **`#` only starts a comment when preceded by whitespace**, so passwords, tokens, and URL fragments keep their full value.
> 
> The line-matching regex is reworked to cover related edge cases: **`KEY= # comment`** yields an empty value (comment text does not leak into env vars), **`#` immediately after a closing quote** still starts a comment, **bare keys** with trailing comments still resolve from **`environ`**, and lines like **`SECRET is documented above`** are ignored instead of being treated as bare keys that could overwrite an earlier explicit assignment.
> 
> New tests in **`test_utils_dotenv.py`** lock in these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16e9f21afb867778acf1b0fc26c9ad453775572c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
