### PR TITLE
[LFS]Fix SliceFileObj.__iter__ yielding only the first 4MB chunk

### DIFF
--- a/src/huggingface_hub/utils/_lfs.py
+++ b/src/huggingface_hub/utils/_lfs.py
@@ -106,4 +106,5 @@ class SliceFileObj(AbstractContextManager):
         return self.fileobj.seek(offset, whence) - self.seek_from
 
     def __iter__(self):
-        yield self.read(n=4 * 1024 * 1024)
+        while data := self.read(n=4 * 1024 * 1024):
+            yield data

--- a/tests/test_lfs.py
+++ b/tests/test_lfs.py
@@ -116,6 +116,18 @@ class TestSliceFileObj:
             assert fileobj_slice.tell() == 0
             assert fileobj_slice.fileobj.tell() == 100
 
+    def test_slice_fileobj_iter_reads_full_slice(self):
+        # Regression test: iterating a slice must yield the whole slice in 4 MB
+        # chunks. Previously __iter__ had a single `yield`, so it returned only the
+        # first 4 MB chunk and silently dropped everything after it.
+        chunk_size = 4 * 1024 * 1024
+        content = b"x" * (chunk_size + 500)  # spans more than one chunk
+        fileobj = BytesIO(content)
+        with SliceFileObj(fileobj, seek_from=0, read_limit=len(content)) as fileobj_slice:
+            chunks = list(fileobj_slice)
+        assert len(chunks) > 1
+        assert b"".join(chunks) == content
+
     def test_slice_fileobj_file(self):
         self.content = b"RANDOM self.content uauabciabeubahveb" * 1024
 


### PR DESCRIPTION

## Summary

- `__iter__` was written with a single `yield`:
```python
  def __iter__(self):
      yield self.read(n=4 * 1024 * 1024)
```
  As a result,  iterating a slice returns at most one 4 MB chunk and silently drops the rest, which is inconsistent with the class's own `read()`, which loops until the slice is exhausted.
- Any consumer that iterates a `SliceFileObj` instead of calling `read()` only sees the first 4 MB.
- fix: loop `read()` until it returns empty, so iteration walks the whole slice.
```python
  def __iter__(self):
      while data := self.read(n=4 * 1024 * 1024):
          yield data
```

### Before / after

```python
>>> import io
>>> from huggingface_hub.utils._lfs import SliceFileObj
>>> data = b"x" * (10 * 1024 * 1024)  # 10 MB
>>> with SliceFileObj(io.BytesIO(data), seek_from=0, read_limit=len(data)) as s:
...     total = len(b"".join(s))
>>> total
# before: 4194304  (only the first 4 MB)
# after:  10485760 (full 10 MB)
```

Added `test_slice_fileobj_iter_reads_full_slice` in `TestSliceFileObj`, which iterates a slice larger than one chunk and asserts the joined result equals the full content.

## Checks

`pytest tests/test_lfs.py` → 7 passed. `ruff format` / `ruff check` clean.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix to iteration behavior with a targeted regression test; upload paths often use fixed part sizes but this closes a silent data-truncation bug when slices exceed 4 MB.
> 
> **Overview**
> **`SliceFileObj.__iter__`** previously did a single `yield self.read(4MB)`, so anything that iterated a slice (instead of calling `read()`) only got the first 4 MB and dropped the rest without error.
> 
> The iterator now **loops** with `while data := self.read(n=4 * 1024 * 1024): yield data`, matching chunked reads until the slice is empty.
> 
> A regression test **`test_slice_fileobj_iter_reads_full_slice`** builds content larger than one chunk, iterates the slice, and asserts the joined chunks equal the full content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b654d0267e6b3f8f6bb5de5659897564dbef82c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->