### PR TITLE
[CLI] Support exact file URIs in hf cache rm

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1633,6 +1633,27 @@ Dry run: no files were deleted.
 
 When working outside the default cache location, pair the command with `--cache-dir PATH`.
 
+To remove an individual cached file, use an exact file URI. For example, keep your other
+quantization variants while removing `model-Q4.gguf`:
+
+```bash
+hf cache rm hf://models/org/model/model-Q4.gguf --dry-run
+hf cache rm hf://models/org/model/model-Q4.gguf
+```
+
+Without `@revision`, the file is selected in **all cached revisions** of that repository.
+Add a cached ref or full commit hash to limit deletion to one revision:
+
+```bash
+hf cache rm hf://models/org/model@main/model-Q4.gguf --dry-run
+```
+
+The preview lists each selected file with its commit hash. Shared blobs are kept while
+another cached file references them, so removing a file can free zero bytes. File paths
+are case-sensitive and must match exactly: folders and wildcard patterns are not expanded.
+Pass multiple file URIs to remove multiple files or shards. File targets cannot be mixed
+with repository or revision targets in the same command.
+
 ### hf cache prune
 
 `hf cache prune` is a convenience shortcut that reclaims space taken by cache garbage: every detached (unreferenced) revision (keeping only revisions still reachable through a branch or tag) and any leftover `.incomplete` files from interrupted downloads:

--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -622,6 +622,31 @@ Proceed with deletion? [y/N]: y
 Deleted 1 repo(s) and 1 revision(s); freed 1.9G.
 ```
 
+To remove one downloaded file while keeping the rest of a repository, use an exact
+`hf://` file URI:
+
+```bash
+hf cache rm hf://models/org/model/model-Q4.gguf --dry-run
+hf cache rm hf://models/org/model/model-Q4.gguf
+```
+
+This selects the file in **all cached revisions**. Use
+`hf://models/org/model@main/model-Q4.gguf` (or a full commit hash instead of `main`)
+to select only one cached revision. The preview shows every affected snapshot entry
+and the expected freed size, counting each unreferenced blob once. Blobs referenced
+by other cached files are retained. Refs, snapshot directories, and other files are
+preserved, even if the selected snapshot becomes empty.
+
+Only exact, case-sensitive file paths are supported. For a sharded variant, pass each
+shard's URI as a separate argument. File targets cannot be combined with whole-repo
+or revision targets. Avoid downloading into or otherwise modifying the cache during
+deletion. Deleted files can be downloaded again; offline use that requires them will
+no longer work until they are restored.
+
+The same operation is available through [`~HFCacheInfo.delete_files`], using
+[`CachedFileInfo`] objects returned by [`scan_cache_dir`]. The returned
+[`DeleteCacheStrategy`] can be inspected before calling `execute()`.
+
 You can also use `hf cache rm` in combination with `hf cache ls --quiet` to bulk-delete entries identified by a filter:
 
 ```bash

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -589,7 +589,7 @@ $ hf cache [OPTIONS] COMMAND [ARGS]...
 
 * `list`: List cached repositories or revisions. [alias: ls]
 * `prune`: Remove detached revisions and incomplete...
-* `rm`: Remove cached repositories or revisions.
+* `rm`: Remove cached repositories, revisions, or...
 * `verify`: Verify checksums for a single repo...
 
 ### `hf cache list`
@@ -651,7 +651,7 @@ Learn more
 
 ### `hf cache rm`
 
-Remove cached repositories or revisions.
+Remove cached repositories, revisions, or individual files.
 
 **Usage**:
 
@@ -661,7 +661,7 @@ $ hf cache rm [OPTIONS] TARGETS...
 
 **Arguments**:
 
-* `TARGETS...`: One or more repo IDs (e.g. model/bert-base-uncased), repo-level hf:// URIs, or revision hashes to delete.  [required]
+* `TARGETS...`: Repo IDs, hf:// repository URIs, or revision hashes to delete. Alternatively, pass exact hf:// file URIs (all cached revisions unless @revision is specified).  [required]
 
 **Options**:
 
@@ -673,6 +673,7 @@ $ hf cache rm [OPTIONS] TARGETS...
 Examples
   $ hf cache rm model/gpt2
   $ hf cache rm hf://models/openai-community/gpt2
+  $ hf cache rm hf://models/org/model/model-Q4.gguf --dry-run
   $ hf cache rm <revision_hash>
   $ hf cache rm model/gpt2 --dry-run
   $ hf cache rm model/gpt2 --yes

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -27,6 +27,7 @@ from huggingface_hub.errors import CLIError
 
 from ..utils import (
     ANSI,
+    CachedFileInfo,
     CachedRepoInfo,
     CachedRevisionInfo,
     CacheNotFound,
@@ -52,6 +53,7 @@ class _DeletionResolution:
     revisions: frozenset[str]
     selected: dict[CachedRepoInfo, frozenset[CachedRevisionInfo]]
     missing: tuple[str, ...]
+    files: frozenset[CachedFileInfo] = frozenset()
 
 
 _FILTER_PATTERN = re.compile(r"^(?P<key>[a-zA-Z_]+)\s*(?P<op>==|!=|>=|<=|>|<|=)\s*(?P<value>.+)$")
@@ -331,6 +333,37 @@ def compile_cache_sort(sort_expr: str) -> tuple[Callable[[CacheEntry], tuple[Any
 
 def _resolve_deletion_targets(hf_cache_info: HFCacheInfo, targets: list[str]) -> _DeletionResolution:
     """Resolve the deletion targets into a deletion resolution."""
+    file_targets = [
+        (target, uri)
+        for target in targets
+        if target.lstrip().startswith("hf://") and (uri := parse_hf_uri(target.lstrip())).path_in_repo
+    ]
+    if file_targets:
+        if len(file_targets) != len([target for target in targets if target.strip()]):
+            raise CLIError("File targets cannot be mixed with repository or revision targets. Run separate commands.")
+        repo_lookup, _ = build_cache_index(hf_cache_info)
+        files: set[CachedFileInfo] = set()
+        missing_files: list[str] = []
+        for target, uri in file_targets:
+            if not uri.is_repo:
+                raise CLIError("Only repository hf:// URIs are supported by `hf cache rm`.")
+            if target.endswith("/"):
+                raise CLIError("File targets must name exact files, not directories.")
+            repo = repo_lookup.get(f"{uri.type}/{uri.id}".lower())
+            matches = {
+                file
+                for revision in (repo.revisions if repo else ())
+                if uri.revision is None or uri.revision == revision.commit_hash or uri.revision in revision.refs
+                for file in revision.files
+                if file.file_path.relative_to(revision.snapshot_path).as_posix() == uri.path_in_repo
+            }
+            if not matches:
+                missing_files.append(target)
+            files.update(matches)
+        return _DeletionResolution(
+            revisions=frozenset(), selected={}, missing=tuple(missing_files), files=frozenset(files)
+        )
+
     repo_lookup, revision_lookup = build_cache_index(hf_cache_info)
 
     selected: dict[CachedRepoInfo, set[CachedRevisionInfo]] = defaultdict(set)
@@ -536,6 +569,7 @@ def ls(
     examples=[
         "hf cache rm model/gpt2",
         "hf cache rm hf://models/openai-community/gpt2",
+        "hf cache rm hf://models/org/model/model-Q4.gguf --dry-run",
         "hf cache rm <revision_hash>",
         "hf cache rm model/gpt2 --dry-run",
         "hf cache rm model/gpt2 --yes",
@@ -545,7 +579,8 @@ def rm(
     targets: Annotated[
         list[str],
         Argument(
-            help="One or more repo IDs (e.g. model/bert-base-uncased), repo-level hf:// URIs, or revision hashes to delete.",
+            help="Repo IDs, hf:// repository URIs, or revision hashes to delete. Alternatively, pass exact hf:// file URIs "
+            "(all cached revisions unless @revision is specified).",
         ),
     ],
     cache_dir: Annotated[
@@ -569,7 +604,7 @@ def rm(
         ),
     ] = False,
 ) -> None:
-    """Remove cached repositories or revisions."""
+    """Remove cached repositories, revisions, or individual files."""
     try:
         hf_cache_info = scan_cache_dir(cache_dir)
     except CacheNotFound as exc:
@@ -580,6 +615,36 @@ def rm(
     if resolution.missing:
         details = "\n".join(f"  - {entry}" for entry in resolution.missing)
         out.warning(f"Could not find in cache:\n{details}")
+
+    if resolution.files:
+        strategy = hf_cache_info.delete_files(*resolution.files)
+        out.text(
+            f"About to delete {len(resolution.files)} cached file(s); "
+            f"expected to free {strategy.expected_freed_size_str}."
+        )
+        # Show the exact snapshot paths, not only basenames: identical filenames
+        # may occur in multiple revisions, and not every selected file frees a blob.
+        for repo in sorted(hf_cache_info.repos, key=lambda repo: repo.cache_id):
+            for revision in sorted(repo.revisions, key=lambda revision: revision.commit_hash):
+                for file in sorted(revision.files & resolution.files, key=lambda file: file.file_path):
+                    path = file.file_path.relative_to(revision.snapshot_path).as_posix()
+                    out.text(f"  - {repo.cache_id}@{revision.commit_hash}/{path}")
+        if dry_run:
+            out.result(
+                "Dry run: no files were deleted.",
+                dry_run=True,
+                files=len(resolution.files),
+                size=strategy.expected_freed_size_str,
+            )
+            return
+        out.confirm("Proceed with deletion?", yes=yes)
+        strategy.execute()
+        out.result(
+            f"Deleted {len(resolution.files)} cached file(s); freed {strategy.expected_freed_size_str}.",
+            files_deleted=len(resolution.files),
+            freed=strategy.expected_freed_size_str,
+        )
+        return
 
     if len(resolution.revisions) == 0:
         out.text("Nothing to delete.")

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -19,6 +19,7 @@ from collections import defaultdict
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from typing import Annotated, Any
 
 import click
@@ -353,7 +354,9 @@ def _resolve_deletion_targets(hf_cache_info: HFCacheInfo, targets: list[str]) ->
             matches = {
                 file
                 for revision in (repo.revisions if repo else ())
-                if uri.revision is None or uri.revision == revision.commit_hash or uri.revision in revision.refs
+                if uri.revision is None
+                or uri.revision.lower() == revision.commit_hash.lower()
+                or uri.revision in {Path(ref).as_posix() for ref in revision.refs}
                 for file in revision.files
                 if file.file_path.relative_to(revision.snapshot_path).as_posix() == uri.path_in_repo
             }

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -258,10 +258,10 @@ class CachedRepoInfo:
 
 @dataclass(frozen=True)
 class DeleteCacheStrategy:
-    """Frozen data structure holding the strategy to delete cached revisions.
+    """Frozen data structure holding the strategy to delete cached revisions or files.
 
     This object is not meant to be instantiated programmatically but to be returned by
-    [`~utils.HFCacheInfo.delete_revisions`]. See documentation for usage example.
+    [`~utils.HFCacheInfo.delete_revisions`] or [`~utils.HFCacheInfo.delete_files`].
 
     Args:
         expected_freed_size (`float`):
@@ -274,6 +274,9 @@ class DeleteCacheStrategy:
             Set of entire repo paths to be deleted.
         snapshots (`frozenset[Path]`):
             Set of snapshots to be deleted (directory of symlinks).
+        files (`frozenset[Path]`):
+            Individual snapshot entries to unlink before deleting unreferenced blobs.
+            Empty by default. Snapshot directories and refs are preserved.
     """
 
     expected_freed_size: int
@@ -281,6 +284,7 @@ class DeleteCacheStrategy:
     refs: frozenset[Path]
     repos: frozenset[Path]
     snapshots: frozenset[Path]
+    files: frozenset[Path] = frozenset()
 
     @property
     def expected_freed_size_str(self) -> str:
@@ -306,6 +310,11 @@ class DeleteCacheStrategy:
         # Deletion order matters. Blobs are deleted in last so that the user can't end
         # up in a state where a `ref`` refers to a missing snapshot or a snapshot
         # symlink refers to a deleted blob.
+
+        # Unlink individual entries first. Do not swallow permission errors here:
+        # deleting their blobs after an unsuccessful unlink would break the cache.
+        for path in self.files:
+            path.unlink(missing_ok=True)
 
         # Delete entire repos
         for path in self.repos:
@@ -389,6 +398,64 @@ class HFCacheInfo:
     def incomplete_size_on_disk(self) -> int:
         """(property) Sum of all incomplete download sizes in bytes."""
         return sum(file.size_on_disk for file in self.incomplete_files)
+
+    def delete_files(self, *files: CachedFileInfo) -> DeleteCacheStrategy:
+        """Prepare deletion of individual files returned by this cache scan.
+
+        Only the selected snapshot entries are removed. Blobs still referenced by
+        other files (including other revisions or repositories) are preserved.
+        Refs and snapshot directories are kept, even if a snapshot becomes empty.
+
+        Args:
+            files (`CachedFileInfo`):
+                Files from this [`HFCacheInfo`]. Unknown files raise `ValueError`
+                before any deletion takes place.
+
+        Example:
+        ```py
+        >>> cache_info = scan_cache_dir()
+        >>> repo = next(repo for repo in cache_info.repos if repo.repo_id == "org/model")
+        >>> files = [file for rev in repo.revisions for file in rev.files if file.file_name == "model-Q4.gguf"]
+        >>> strategy = cache_info.delete_files(*files)
+        >>> print(strategy.expected_freed_size_str)
+        >>> strategy.execute()
+        ```
+
+        As with [`~HFCacheInfo.delete_revisions`], execute the strategy promptly
+        and do not modify or download into the cache between scanning and deletion.
+        Only blobs inside scanned repositories' `blobs` directories are reclaimed;
+        symlinks to external data are unlinked without deleting their targets.
+        """
+        selected = set(files)
+        cached_files = {file for repo in self.repos for rev in repo.revisions for file in rev.files}
+        if unknown := selected - cached_files:
+            raise ValueError(
+                f"File(s) not found in this cache scan: {', '.join(sorted(str(f.file_path) for f in unknown))}"
+            )
+
+        retained_blobs = {file.blob_path for file in cached_files - selected}
+        blob_dirs = {repo.repo_path / "blobs" for repo in self.repos}
+        blobs: set[Path] = set()
+        freed: dict[Path, int] = {}
+        for file in selected:
+            if file.file_path == file.blob_path:
+                # Without symlinks, data lives in the snapshot itself. A user may
+                # also have linked another snapshot entry to that directly stored file.
+                if file.blob_path in retained_blobs:
+                    raise ValueError(f"Cannot delete a file still referenced by another cached file: {file.file_path}")
+                freed[file.file_path] = file.size_on_disk
+            elif file.blob_path not in retained_blobs and file.blob_path.parent in blob_dirs:
+                blobs.add(file.blob_path)
+                freed[file.blob_path] = file.size_on_disk
+
+        return DeleteCacheStrategy(
+            expected_freed_size=sum(freed.values()),
+            blobs=frozenset(blobs),
+            refs=frozenset(),
+            repos=frozenset(),
+            snapshots=frozenset(),
+            files=frozenset(file.file_path for file in selected),
+        )
 
     def delete_revisions(self, *revisions: str) -> DeleteCacheStrategy:
         """Prepare the strategy to delete one or more revisions cached locally.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,8 +3,9 @@ import os
 import sys
 import warnings
 from contextlib import contextmanager
+from dataclasses import replace
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from types import SimpleNamespace
 from typing import Generator, Optional
 from unittest.mock import Mock, patch
@@ -21,7 +22,7 @@ from huggingface_hub._space_api import Volume
 from huggingface_hub.cli import _skills, extensions, system
 from huggingface_hub.cli._cli_utils import RepoType, _get_huggingface_hub_update_command, parse_volumes
 from huggingface_hub.cli._output import OutputFormat, out
-from huggingface_hub.cli.cache import CacheDeletionCounts
+from huggingface_hub.cli.cache import CacheDeletionCounts, _resolve_deletion_targets
 from huggingface_hub.cli.download import download
 from huggingface_hub.cli.hf import app
 from huggingface_hub.cli.hf import main as hf_main
@@ -5221,7 +5222,7 @@ class TestCacheFileDeletion:
                     path.symlink_to(repo / "blobs" / name)
         return tmp_path, repo
 
-    @pytest.mark.parametrize("revision", ["", "@main", "@" + "b" * 40])
+    @pytest.mark.parametrize("revision", ["", "@main", "@" + "b" * 40, "@" + "B" * 40])
     def test_file_preview_confirmation_and_deletion(self, runner, file_cache, revision):
         cache, repo = file_cache
         target = f"hf://models/org/model{revision}/weights/Q4.gguf"
@@ -5271,3 +5272,23 @@ class TestCacheFileDeletion:
             assert "Nothing to delete." in result.output
         assert len(list(repo.glob("snapshots/*/weights/*.gguf"))) == 4
         assert not scan_cache_dir(cache).warnings
+
+    def test_windows_ref_separators_preserve_ref_case(self, file_cache):
+        cache, _ = file_cache
+        info = scan_cache_dir(cache)
+        repo = next(iter(info.repos))
+        revisions = frozenset(
+            replace(rev, refs=frozenset({r"refs\pr\1", r"Feature\Branch"})) if rev.commit_hash == "a" * 40 else rev
+            for rev in repo.revisions
+        )
+        info = replace(info, repos=frozenset({replace(repo, revisions=revisions)}))
+        # Exercise Windows path normalization on every test platform.
+        with patch("huggingface_hub.cli.cache.Path", PureWindowsPath, create=True):
+            for ref in ("refs/pr/1", "Feature%2FBranch"):
+                result = _resolve_deletion_targets(info, [f"hf://models/org/model@{ref}/weights/Q4.gguf"])
+                assert not result.missing
+                assert len(result.files) == 1
+                assert next(iter(result.files)).file_path.parts[-3] == "a" * 40
+            result = _resolve_deletion_targets(info, ["hf://models/org/model@feature%2Fbranch/weights/Q4.gguf"])
+            assert not result.files
+            assert result.missing

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,6 +37,7 @@ from huggingface_hub.utils import (
     CachedRevisionInfo,
     HFCacheInfo,
     SoftTemporaryDirectory,
+    scan_cache_dir,
 )
 from huggingface_hub.utils._verification import FolderVerification
 
@@ -221,19 +222,12 @@ class TestCacheCommand:
         hf_cache_info.delete_revisions.assert_called_once_with(revision.commit_hash)
         strategy.execute.assert_called_once_with()
 
-    @pytest.mark.parametrize(
-        "target",
-        [
-            "hf://models/openai-community/gpt2@main",
-            "hf://models/openai-community/gpt2/config.json",
-        ],
-    )
-    def test_rm_hf_uri_rejects_revisions_and_paths(self, runner: CliRunner, target: str) -> None:
+    def test_rm_hf_uri_rejects_revision_without_path(self, runner: CliRunner) -> None:
         with (
             patch("huggingface_hub.cli.cache.scan_cache_dir"),
             patch("huggingface_hub.cli.cache.build_cache_index", return_value=({}, {})),
         ):
-            result = runner.invoke(app, ["cache", "rm", target])
+            result = runner.invoke(app, ["cache", "rm", "hf://models/openai-community/gpt2@main"])
 
         assert result.exit_code == 1
         assert isinstance(result.exception, CLIError)
@@ -5205,3 +5199,75 @@ class TestExtensionsGitHubAccess:
         assert "It resets at" not in str(result.exception)
         # Bailed out on the first extension rather than repeating the failure for every one of them.
         assert len(github.api_urls) == 1
+
+
+class TestCacheFileDeletion:
+    @pytest.fixture
+    def file_cache(self, tmp_path):
+        repo = tmp_path / "models--org--model"
+        (repo / "blobs").mkdir(parents=True)
+        (repo / "refs").mkdir()
+        (repo / "refs" / "main").write_text("a" * 40)
+        for name, content in {"Q4.gguf": b"4" * 100, "Q8.gguf": b"8" * 200}.items():
+            (repo / "blobs" / name).write_bytes(content)
+            for commit in ("a" * 40, "b" * 40):
+                path = repo / "snapshots" / commit / "weights" / name
+                path.parent.mkdir(parents=True, exist_ok=True)
+                # A real symlink cache where supported; direct files exercise the
+                # Windows layout without requiring symlink privileges.
+                if os.name == "nt":
+                    path.write_bytes(content)
+                else:
+                    path.symlink_to(repo / "blobs" / name)
+        return tmp_path, repo
+
+    @pytest.mark.parametrize("revision", ["", "@main", "@" + "b" * 40])
+    def test_file_preview_confirmation_and_deletion(self, runner, file_cache, revision):
+        cache, repo = file_cache
+        target = f"hf://models/org/model{revision}/weights/Q4.gguf"
+        args = ["cache", "rm", target, target, "--cache-dir", str(cache)]
+        expected_commits = ["a" * 40, "b" * 40] if not revision else ["a" * 40 if revision == "@main" else "b" * 40]
+        result = runner.invoke(app, args + ["--dry-run"])
+        assert result.exit_code == 0, result.output
+        assert f"About to delete {len(expected_commits)} cached file(s)" in result.output
+        for commit in expected_commits:
+            assert f"model/org/model@{commit}/weights/Q4.gguf" in result.output
+        assert "Q8.gguf" not in result.output
+        assert "Dry run: no files were deleted." in result.output
+        expected_freed = len(expected_commits) * 100 if os.name == "nt" else (100 if not revision else 0)
+        assert f"expected to free {expected_freed:.1f}." in result.output
+        result = runner.invoke(app, args, input="n\n")
+        assert result.exit_code != 0
+        assert len(list(repo.glob("snapshots/*/weights/Q4.gguf"))) == 2
+        result = runner.invoke(app, args + ["--yes"])
+        assert result.exit_code == 0, result.output
+        for commit in ("a" * 40, "b" * 40):
+            assert (repo / "snapshots" / commit / "weights" / "Q4.gguf").exists() == (commit not in expected_commits)
+            assert (repo / "snapshots" / commit / "weights" / "Q8.gguf").read_bytes() == b"8" * 200
+        assert (repo / "refs" / "main").read_text() == "a" * 40
+        assert not scan_cache_dir(cache).warnings
+
+    @pytest.mark.parametrize(
+        "targets,invalid",
+        [
+            (["hf://models/org/model/weights"], False),
+            (["hf://models/org/model/weights/*.gguf"], False),
+            (["hf://models/org/model/weights/q4.gguf"], False),
+            (["hf://models/org/model/weights/Q4.gguf "], False),
+            (["hf://models/org/model/weights/Q4.gguf/"], True),
+            (["hf://models/org/model@missing/weights/Q4.gguf"], False),
+            (["hf://models/org/model/../../blobs/Q4.gguf"], False),
+            (["hf://models/org/model/weights/Q4.gguf", "model/org/model"], True),
+            (["hf://models/org/model/weights/Q4.gguf", "a" * 40], True),
+            (["hf://buckets/org/model/weights/Q4.gguf"], True),
+        ],
+    )
+    def test_unmatched_and_invalid_file_targets_never_delete(self, runner, file_cache, targets, invalid):
+        cache, repo = file_cache
+        result = runner.invoke(app, ["cache", "rm", *targets, "--cache-dir", str(cache), "--yes"])
+        assert (result.exit_code != 0) == invalid
+        if not invalid:
+            assert "Could not find in cache:" in result.output
+            assert "Nothing to delete." in result.output
+        assert len(list(repo.glob("snapshots/*/weights/*.gguf"))) == 4
+        assert not scan_cache_dir(cache).warnings

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -1,8 +1,9 @@
 import logging
 import os
 import time
+from dataclasses import replace
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -745,3 +746,117 @@ class TestStringFormatters:
         """Test `_format_size` formatter."""
         for size, expected in self.SIZES.items():
             assert _format_size(size) == expected, f"Wrong formatting for {size} == '{expected}'"
+
+
+class TestDeleteFiles:
+    @pytest.fixture
+    def cached_files(self, tmp_path):
+        repo = tmp_path / "models--org--model"
+        snapshot = repo / "snapshots" / ("a" * 40)
+        snapshot.mkdir(parents=True)
+        (repo / "refs").mkdir()
+        (repo / "refs" / "main").write_text("a" * 40)
+        (repo / "blobs").mkdir()
+        (repo / "blobs" / "weights").write_bytes(b"q" * 100)
+        (snapshot / "config.json").write_bytes(b"{}")
+        return repo, snapshot
+
+    @pytest.mark.skipif(os.name == "nt", reason="Requires symlinks; direct-file deletion is tested separately")
+    def test_shared_blobs_and_aliases_survive_until_last_reference(self, tmp_path, cached_files):
+        repo, snapshot = cached_files
+        old = repo / "snapshots" / ("b" * 40)
+        old.mkdir()
+        for path in (snapshot / "Q4.gguf", snapshot / "alias.gguf", old / "Q4.gguf"):
+            path.symlink_to(repo / "blobs" / "weights")
+        info = scan_cache_dir(tmp_path)
+        selected = [f for r in info.repos for rev in r.revisions for f in rev.files if f.file_name == "Q4.gguf"]
+        strategy = info.delete_files(*selected, *selected)
+        assert len(strategy.files) == 2
+        assert strategy.expected_freed_size == 0
+        assert not strategy.blobs
+        assert all(path.exists() for path in strategy.files)  # planning is read-only
+        strategy.execute()
+        assert (snapshot / "alias.gguf").read_bytes() == b"q" * 100
+        assert (snapshot / "config.json").read_bytes() == b"{}"
+        assert (repo / "refs" / "main").read_text() == "a" * 40
+        assert old.is_dir()  # empty snapshots remain valid
+        info = scan_cache_dir(tmp_path)
+        assert not info.warnings
+        alias = next(f for r in info.repos for rev in r.revisions for f in rev.files if f.file_name == "alias.gguf")
+        strategy = info.delete_files(alias)
+        assert strategy.expected_freed_size == 100
+        assert strategy.blobs == {repo / "blobs" / "weights"}
+        strategy.execute()
+        assert not (repo / "blobs" / "weights").exists()
+        assert scan_cache_dir(tmp_path).size_on_disk == 2
+
+    def test_direct_files_and_unknown_targets(self, tmp_path, cached_files):
+        repo, snapshot = cached_files
+        (snapshot / "Q4.gguf").write_bytes(b"q" * 100)
+        info = scan_cache_dir(tmp_path)
+        files = [f for r in info.repos for rev in r.revisions for f in rev.files]
+        selected = next(f for f in files if f.file_name == "Q4.gguf")
+        external = tmp_path.parent / "not-in-cache.gguf"
+        forged = replace(selected, file_path=external, blob_path=external)
+        with pytest.raises(ValueError, match="not found in this cache scan"):
+            info.delete_files(selected, forged)
+        assert selected.file_path.exists()
+        assert info.delete_files().expected_freed_size == 0
+        strategy = info.delete_files(*files)
+        assert strategy.expected_freed_size == 102
+        assert not strategy.blobs  # data is removed by unlinking the snapshot entry
+        strategy.execute()
+        report = scan_cache_dir(tmp_path)
+        assert not report.warnings
+        assert report.size_on_disk == 0
+        assert snapshot.is_dir()
+        assert (repo / "refs" / "main").exists()
+
+    @pytest.mark.skipif(os.name == "nt", reason="Requires symlinks")
+    def test_cross_repo_references_and_external_targets(self, tmp_path, cached_files):
+        repo, snapshot = cached_files
+        other = tmp_path / "models--org--other" / "snapshots" / ("b" * 40)
+        other.mkdir(parents=True)
+        (snapshot / "Q4.gguf").symlink_to(repo / "blobs" / "weights")
+        (other / "shared.gguf").symlink_to(repo / "blobs" / "weights")
+        # Outside the managed blobs directory, even though scan_cache_dir accepts the link.
+        external = repo / "external.gguf"
+        external.write_bytes(b"external")
+        (snapshot / "external.gguf").symlink_to(external)
+        info = scan_cache_dir(tmp_path)
+        files = [
+            f
+            for r in info.repos
+            for rev in r.revisions
+            for f in rev.files
+            if f.file_name in {"Q4.gguf", "external.gguf"}
+        ]
+        strategy = info.delete_files(*files)
+        assert strategy.expected_freed_size == 0
+        strategy.execute()
+        assert (other / "shared.gguf").read_bytes() == b"q" * 100
+        assert external.read_bytes() == b"external"
+        assert not scan_cache_dir(tmp_path).warnings
+
+    @pytest.mark.skipif(os.name == "nt", reason="Requires symlinks")
+    def test_referenced_direct_file_cannot_be_deleted(self, tmp_path, cached_files):
+        _, snapshot = cached_files
+        (snapshot / "alias.json").symlink_to(snapshot / "config.json")
+        info = scan_cache_dir(tmp_path)
+        config = next(f for r in info.repos for rev in r.revisions for f in rev.files if f.file_name == "config.json")
+        with pytest.raises(ValueError, match="still referenced"):
+            info.delete_files(config)
+        assert (snapshot / "alias.json").read_bytes() == b"{}"
+
+    @pytest.mark.skipif(os.name == "nt", reason="Requires symlinks")
+    def test_unlink_failure_does_not_delete_blob(self, tmp_path, cached_files):
+        repo, snapshot = cached_files
+        path = snapshot / "Q4.gguf"
+        path.symlink_to(repo / "blobs" / "weights")
+        info = scan_cache_dir(tmp_path)
+        file = next(f for r in info.repos for rev in r.revisions for f in rev.files if f.file_path == path)
+        strategy = info.delete_files(file)
+        with patch.object(Path, "unlink", side_effect=PermissionError("cannot unlink")):
+            with pytest.raises(PermissionError):
+                strategy.execute()
+        assert path.read_bytes() == b"q" * 100


### PR DESCRIPTION
## Summary

Users caching multiple GGUF quantizations currently have to remove an entire cached revision to reclaim space through `hf cache rm`. This adds exact file URIs so they can remove unwanted weights while retaining other files.

- Follow-up to #4235 and the `hf://` direction discussed in #4226; related to #4124. This is an incremental implementation, not a complete quantization/shard discovery feature.
- `hf cache rm hf://models/org/model/model-Q4.gguf` selects that exact, case-sensitive path across cached revisions. `@main` or a full commit hash limits selection to one cached revision, resolved locally. Multiple file URIs can select individual shards.
- `HFCacheInfo.delete_files` creates an inspectable deletion strategy. Shared blobs are retained until their last scanned reference is removed; refs, snapshot directories, and unrelated files remain. Dry-run previews show every selected revision/path and count each reclaimed blob once.

No changes to existing repository/revision deletion behavior. File and whole-repository/revision targets cannot be mixed; folders and globs are deliberately excluded to keep destructive selection explicit. Avoid concurrent cache modifications between scanning and executing, as with existing deletion strategies. Deleted files must be downloaded again before offline use that requires them.

Manual check with a temporary cache containing two revisions sharing Q4 (1 KiB) and Q8 (2 KiB) payloads; both commands also received `--cache-dir <temporary-directory>`:

```text
$ hf cache rm hf://models/example/demo@main/Q4.gguf --dry-run
About to delete 1 cached file(s); expected to free 0.0.
  - model/example/demo@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Q4.gguf
✓ Dry run: no files were deleted.
  dry_run: True
  files: 1
  size: 0.0
$ hf cache rm hf://models/example/demo/Q4.gguf --yes
About to delete 2 cached file(s); expected to free 1.0K.
  - model/example/demo@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Q4.gguf
  - model/example/demo@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/Q4.gguf
files_deleted=2 freed=1.0K
```

Afterward, `try_to_load_from_cache` still returned readable Q8 weights and returned `None` for Q4; a fresh cache scan reported no warnings and 2 KiB retained. Both snapshots and the main ref remained.

Validation: `make style`, `make quality` (including `ty` and generated documentation), and `mypy src` passed. The non-production CLI/cache/URI suite passed with 506 tests and 25 deselected. Regression coverage includes shared blobs and aliases, direct-file cache layouts, cross-repository references, external symlink targets, failed unlink, invalid/mixed targets, preview, cancellation, and revision selection. Windows-specific execution still needs upstream CI; direct-file behavior was exercised locally on Linux.

The implementation was developed with AI assistance. It follows the earlier upstream discussion and acknowledges the related closed prototype at tonycoder-hub/huggingface_hub#6; no code from that prototype was copied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes irreversible local cache deletion logic (new code paths in `delete_files` and CLI resolution), though existing repo/revision removal is unchanged; incorrect targeting could remove needed weights until re-download.
> 
> **Overview**
> **`hf cache rm`** now accepts exact **`hf://` file URIs** so users can drop individual cached files (e.g. one GGUF quantization) without removing whole repos or revisions. Optional **`@revision`** scopes deletion to one cached snapshot; multiple URIs work for shards. File targets cannot be mixed with repo/revision targets; paths must be exact (no folders or globs).
> 
> The Python API adds **`HFCacheInfo.delete_files`**, which builds a **`DeleteCacheStrategy`** that unlinks selected snapshot entries and reclaims blobs only when no other scanned file still references them—refs and snapshot dirs stay intact. CLI dry-run/confirm output lists each `repo@commit/path` and expected freed size.
> 
> Docs and CLI reference are updated accordingly; tests cover shared blobs, direct-file layouts, invalid targets, and Windows ref normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64f36415e58d78e4fab0580e856132421d294f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->