### PR TITLE
[CLI] Raise explicit error for shell-script extensions on Windows

### DIFF
--- a/docs/source/en/guides/cli-extensions.md
+++ b/docs/source/en/guides/cli-extensions.md
@@ -39,6 +39,10 @@ falls back to installing the repo as a Python package.
 A shell script extension is the simplest type. You only need a GitHub repository with an executable file
 named `hf-<name>` at the root.
 
+> [!WARNING]
+> Shell script extensions are not supported on Windows. If your extension must work on Windows, make it a
+> [Python extension](#create-a-python-extension) instead.
+
 ### Minimal example
 
 Create a repository named `hf-hello` on GitHub with a single file:

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -375,11 +375,8 @@ def _auto_install_official_extension(short_name: str) -> Path | None:
         out.confirm(f"'{short_name}' is an official Hugging Face extension ({owner}/{repo_name}). Install it?")
     except ConfirmationError:
         return None
-    try:
-        manifest = _install_extension(owner=owner, repo_name=repo_name, short_name=short_name)
-        return Path(manifest.executable_path).expanduser()
-    except Exception:
-        return None
+    manifest = _install_extension(owner=owner, repo_name=repo_name, short_name=short_name)
+    return Path(manifest.executable_path).expanduser()
 
 
 def _load_installed_extension_for_update(name: str) -> ExtensionManifest:

--- a/src/huggingface_hub/cli/extensions.py
+++ b/src/huggingface_hub/cli/extensions.py
@@ -435,6 +435,11 @@ def _install_extension(
             binary = None
 
         if binary is not None:
+            if os.name == "nt":
+                raise CLIError(
+                    f"'{owner}/{repo_name}' is a shell-script extension, which is not supported on Windows. "
+                    "Only Python extensions can be installed on Windows."
+                )
             executable_path = _install_binary_extension(
                 extension_dir=extension_dir, short_name=short_name, binary=binary
             )
@@ -500,8 +505,7 @@ def _fetch_latest_commit_sha(*, owner: str, repo_name: str) -> str:
 
 
 def _fetch_remote_binary(*, owner: str, repo_name: str, short_name: str) -> bytes:
-    executable_name = _get_executable_name(short_name)
-    raw_url = f"https://raw.githubusercontent.com/{owner}/{repo_name}/HEAD/{executable_name}"
+    raw_url = f"https://raw.githubusercontent.com/{owner}/{repo_name}/HEAD/hf-{short_name}"
     response = _github_request("GET", raw_url)
     return response.content
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5185,6 +5185,18 @@ class TestExtensionsGitHubAccess:
             extensions._install_extension(owner="huggingface", repo_name="hf-demo", short_name="demo")
         assert not (extensions.EXTENSIONS_ROOT / "hf-demo").exists()
 
+    def test_auto_install_surfaces_install_errors(self, github: _FakeGitHubSession) -> None:
+        github.responses = {
+            REPO_PAGE_URL: httpx.Response(200),
+            BINARY_URL: httpx.Response(200, content=b"#!/bin/sh"),
+        }
+        with (
+            patch.object(extensions.out, "confirm"),
+            patch.object(os, "name", "nt"),
+            pytest.raises(CLIError, match="not supported on Windows"),
+        ):
+            extensions.dispatch_unknown_top_level_extension(["demo"], {"jobs", "repos"})
+
     def test_unreachable_github_is_not_reported_as_a_missing_repo(
         self, github: _FakeGitHubSession, runner: CliRunner
     ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5140,6 +5140,7 @@ class TestExtensionsGitHubAccess:
             ("Contribute to huggingface/hf-demo development by creating an account on GitHub.", None),
         ],
     )
+    @pytest.mark.skipif(os.name == "nt", reason="Shell-script extensions are not supported on Windows.")
     def test_install_uses_head_refs_and_a_single_api_call(
         self, github: _FakeGitHubSession, about: str, expected_description: str | None
     ) -> None:
@@ -5161,6 +5162,7 @@ class TestExtensionsGitHubAccess:
         raw_urls = [url for url in github.urls if url.startswith(raw_prefix)]
         assert raw_urls and all(url.removeprefix(raw_prefix).startswith("HEAD/") for url in raw_urls)
 
+    @pytest.mark.skipif(os.name == "nt", reason="Shell-script extensions are not supported on Windows.")
     def test_install_completes_when_the_api_quota_is_exhausted(self, github: _FakeGitHubSession) -> None:
         # The extension itself comes from the CDN, so only the optional version marker is lost.
         github.responses = {
@@ -5173,6 +5175,15 @@ class TestExtensionsGitHubAccess:
         assert manifest.commit_sha is None
         assert manifest.description == "Demo extension"
         assert Path(manifest.executable_path).is_file()
+
+    def test_install_rejects_shell_script_extension_on_windows(self, github: _FakeGitHubSession) -> None:
+        github.responses = {BINARY_URL: httpx.Response(200, content=b"#!/bin/sh")}
+        with (
+            patch.object(os, "name", "nt"),
+            pytest.raises(CLIError, match="not supported on Windows"),
+        ):
+            extensions._install_extension(owner="huggingface", repo_name="hf-demo", short_name="demo")
+        assert not (extensions.EXTENSIONS_ROOT / "hf-demo").exists()
 
     def test_unreachable_github_is_not_reported_as_a_missing_repo(
         self, github: _FakeGitHubSession, runner: CliRunner

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5176,27 +5176,6 @@ class TestExtensionsGitHubAccess:
         assert manifest.description == "Demo extension"
         assert Path(manifest.executable_path).is_file()
 
-    def test_install_rejects_shell_script_extension_on_windows(self, github: _FakeGitHubSession) -> None:
-        github.responses = {BINARY_URL: httpx.Response(200, content=b"#!/bin/sh")}
-        with (
-            patch.object(os, "name", "nt"),
-            pytest.raises(CLIError, match="not supported on Windows"),
-        ):
-            extensions._install_extension(owner="huggingface", repo_name="hf-demo", short_name="demo")
-        assert not (extensions.EXTENSIONS_ROOT / "hf-demo").exists()
-
-    def test_auto_install_surfaces_install_errors(self, github: _FakeGitHubSession) -> None:
-        github.responses = {
-            REPO_PAGE_URL: httpx.Response(200),
-            BINARY_URL: httpx.Response(200, content=b"#!/bin/sh"),
-        }
-        with (
-            patch.object(extensions.out, "confirm"),
-            patch.object(os, "name", "nt"),
-            pytest.raises(CLIError, match="not supported on Windows"),
-        ):
-            extensions.dispatch_unknown_top_level_extension(["demo"], {"jobs", "repos"})
-
     def test_unreachable_github_is_not_reported_as_a_missing_repo(
         self, github: _FakeGitHubSession, runner: CliRunner
     ) -> None:


### PR DESCRIPTION
Follow-up to Wauplin's suggestion in https://github.com/huggingface/huggingface_hub/pull/4764#issuecomment-5581909996.

## Summary

- Shell-script extensions never worked on Windows: the installer looked for `hf-<name>.exe`, didn't find it, fell back to a Python install and failed with a confusing uv/pip error (see https://github.com/huggingface/hf-claude/issues/5).
- `hf extensions install` now fails early with an explicit error when the repo ships a shell-script extension and the user is on Windows. Python extensions are unchanged.
- Added a note to the extensions guide.

Error shown on Windows:

```
'huggingface/hf-claude' is a shell-script extension, which is not supported on Windows. Only Python extensions can be installed on Windows.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted CLI install-path change for Windows plus clearer errors; Python extension installs and non-Windows behavior are unchanged aside from the binary URL probe fix.
> 
> **Overview**
> **Windows users** installing a repo that ships a root **`hf-<name>`** shell script no longer fall through to a Python/uv install and obscure pip errors. **`hf extensions install`** (and auto-install after confirmation) now **fails fast** with an explicit message that only Python extensions work on Windows.
> 
> The remote binary probe always requests **`hf-{short_name}`** from raw GitHub (not a **`.exe`** name on Windows), so shell-script repos are detected correctly before install logic runs.
> 
> **Auto-install** of official extensions no longer swallows install failures in a broad **`try/except`**, so real install errors surface after the user confirms.
> 
> The extensions guide adds a **warning** that shell-script extensions are unsupported on Windows. Shell-script install tests are **skipped on Windows** in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8db1543de1a07fc14d74dcc06c5cdaeab0d44b77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->