### PR TITLE
[CLI] Support file URIs in hf cache rm

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1600,7 +1600,7 @@ Deleted 2 repo(s) and 2 revision(s); freed 5.31G.
 
 ### hf cache rm
 
-`hf cache rm` removes cached repositories or individual revisions. Pass one or more repo IDs (`model/bert-base-uncased`), repo-level `hf://` URIs, or revision hashes:
+`hf cache rm` removes cached repositories, individual revisions or single files. Pass one or more repo IDs (`model/bert-base-uncased`), `hf://` URIs, or revision hashes:
 
 ```bash
 >>> hf cache rm model/LiquidAI/LFM2-VL-1.6B
@@ -1620,6 +1620,17 @@ About to delete 1 repo(s) totalling 1.1G.
   - model/openai-community/gpt2 (entire repo)
 Dry run: no files were deleted.
 ```
+
+To remove a single file instead of a whole repository, for example one GGUF quantization, pass an `hf://` file URI. The file is removed from every cached revision of the repo, and its blob is deleted only if no other cached file still references it:
+
+```bash
+>>> hf cache rm hf://models/unsloth/gemma-3-27b-it-GGUF/gemma-3-27b-it-Q4_K_M.gguf --dry-run
+About to delete 1 file(s) totalling 16.5G.
+  - model/unsloth/gemma-3-27b-it-GGUF@3f4b5c1d2e6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c/gemma-3-27b-it-Q4_K_M.gguf
+Dry run: no files were deleted.
+```
+
+Paths must match exactly: folders and glob patterns are not supported, and file targets cannot be mixed with repositories or revisions in the same call.
 
 Mix repositories and specific revisions in the same call. Use `--dry-run` to preview the impact, or `--yes` to skip the confirmation prompt—handy in automated scripts:
 

--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1630,7 +1630,7 @@ About to delete 1 file(s) totalling 16.5G.
 Dry run: no files were deleted.
 ```
 
-Paths must match exactly: folders and glob patterns are not supported, and file targets cannot be mixed with repositories or revisions in the same call.
+The revision stays usable, and a deleted file is downloaded again the next time it is needed. Paths must match exactly: folders and glob patterns are not supported, and file targets cannot be mixed with repositories or revisions in the same call.
 
 Mix repositories and specific revisions in the same call. Use `--dry-run` to preview the impact, or `--yes` to skip the confirmation prompt—handy in automated scripts:
 

--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -652,7 +652,8 @@ Dry run: no files were deleted.
 
 To remove a single file instead of a whole repository, for example one GGUF quantization,
 pass an `hf://` file URI. The file is removed from every cached revision of the repo, and
-its blob is deleted only if no other cached file still references it. Paths must match
+its blob is deleted only if no other cached file still references it. The revision stays
+usable, and a deleted file is downloaded again the next time it is needed. Paths must match
 exactly: folders and glob patterns are not supported.
 
 ```text

--- a/docs/source/en/guides/manage-cache.md
+++ b/docs/source/en/guides/manage-cache.md
@@ -579,8 +579,8 @@ Verify a specific cached revision:
 Scanning your cache is interesting but what you really want to do next is usually to
 delete some portions to free up some space on your drive. This is possible using the
 `hf cache rm` and `hf cache prune` CLI commands. One can also programmatically use the
-[`~HFCacheInfo.delete_revisions`] helper from the [`HFCacheInfo`] object returned when
-scanning the cache.
+[`~HFCacheInfo.delete_revisions`] and [`~HFCacheInfo.delete_files`] helpers from the
+[`HFCacheInfo`] object returned when scanning the cache.
 
 **Delete strategy**
 
@@ -597,6 +597,10 @@ The strategy to delete revisions is the following:
 - blobs files that are targeted only by revisions to be deleted are deleted as well.
 - if a revision is linked to 1 or more `refs`, references are deleted.
 - if all revisions from a repo are deleted, the entire cached repository is deleted.
+
+Deleting individual files with [`~HFCacheInfo.delete_files`] follows the same logic: the
+snapshot entries are removed, and their blobs are deleted only if no other cached file
+references them. Refs and snapshot folders are kept.
 
 > [!TIP]
 > Revision hashes are unique across all repositories. `hf cache rm` therefore accepts either
@@ -643,6 +647,18 @@ or `--yes` to skip the confirmation prompt when scripting:
 About to delete 1 repo(s) and 1 revision(s) totalling 1.1G.
   - model/t5-small:
       8f3ad1c [main] 1.1G
+Dry run: no files were deleted.
+```
+
+To remove a single file instead of a whole repository, for example one GGUF quantization,
+pass an `hf://` file URI. The file is removed from every cached revision of the repo, and
+its blob is deleted only if no other cached file still references it. Paths must match
+exactly: folders and glob patterns are not supported.
+
+```text
+➜ hf cache rm hf://models/unsloth/gemma-3-27b-it-GGUF/gemma-3-27b-it-Q4_K_M.gguf --dry-run
+About to delete 1 file(s) totalling 16.5G.
+  - model/unsloth/gemma-3-27b-it-GGUF@3f4b5c1d2e6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c/gemma-3-27b-it-Q4_K_M.gguf
 Dry run: no files were deleted.
 ```
 

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -589,7 +589,7 @@ $ hf cache [OPTIONS] COMMAND [ARGS]...
 
 * `list`: List cached repositories or revisions. [alias: ls]
 * `prune`: Remove detached revisions and incomplete...
-* `rm`: Remove cached repositories or revisions.
+* `rm`: Remove cached repositories, revisions or...
 * `verify`: Verify checksums for a single repo...
 
 ### `hf cache list`
@@ -651,7 +651,7 @@ Learn more
 
 ### `hf cache rm`
 
-Remove cached repositories or revisions.
+Remove cached repositories, revisions or files.
 
 **Usage**:
 
@@ -661,7 +661,7 @@ $ hf cache rm [OPTIONS] TARGETS...
 
 **Arguments**:
 
-* `TARGETS...`: One or more repo IDs (e.g. model/bert-base-uncased), repo-level hf:// URIs, or revision hashes to delete.  [required]
+* `TARGETS...`: One or more repo IDs (e.g. model/bert-base-uncased), hf:// URIs (repo or file), or revision hashes to delete.  [required]
 
 **Options**:
 
@@ -673,6 +673,7 @@ $ hf cache rm [OPTIONS] TARGETS...
 Examples
   $ hf cache rm model/gpt2
   $ hf cache rm hf://models/openai-community/gpt2
+  $ hf cache rm hf://models/openai-community/gpt2/model.safetensors
   $ hf cache rm <revision_hash>
   $ hf cache rm model/gpt2 --dry-run
   $ hf cache rm model/gpt2 --yes

--- a/src/huggingface_hub/cli/_errors.py
+++ b/src/huggingface_hub/cli/_errors.py
@@ -145,7 +145,6 @@ CLI_ERROR_MAPPINGS: dict[type[Exception], Callable[..., str]] = {
     ValueError: lambda error: f"Invalid value. {error}",
     CLIExtensionInstallError: _format_cli_extension_install_error,
     CLIError: _format_cli_error,
-    OSError: lambda error: str(error),  # e.g. permission denied while deleting cache files
 }
 
 

--- a/src/huggingface_hub/cli/_errors.py
+++ b/src/huggingface_hub/cli/_errors.py
@@ -145,6 +145,7 @@ CLI_ERROR_MAPPINGS: dict[type[Exception], Callable[..., str]] = {
     ValueError: lambda error: f"Invalid value. {error}",
     CLIExtensionInstallError: _format_cli_extension_install_error,
     CLIError: _format_cli_error,
+    OSError: lambda error: str(error),  # e.g. permission denied while deleting cache files
 }
 
 

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -160,10 +160,12 @@ def _parse_hf_uri_target(target: str) -> HfUri:
     if not uri.is_repo:
         raise CLIError("Only repository hf:// URIs are supported by `hf cache rm`.")
     if uri.revision is not None:
-        raise CLIError(
-            "Revisions in hf:// URIs are not supported by `hf cache rm`. Pass a revision hash to delete a revision, "
-            "or drop '@<revision>' to delete a file from all cached revisions."
+        hint = (
+            "Drop '@<revision>' to delete the file from all cached revisions."
+            if uri.path_in_repo
+            else "Pass the revision hash instead, see 'hf cache ls --revisions'."
         )
+        raise CLIError(f"Revisions in hf:// URIs are not supported by `hf cache rm`. {hint}")
     return uri
 
 

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -342,6 +342,7 @@ def compile_cache_sort(sort_expr: str) -> tuple[Callable[[CacheEntry], tuple[Any
 
 def _resolve_deletion_targets(hf_cache_info: HFCacheInfo, targets: list[str]) -> _DeletionResolution:
     """Resolve the deletion targets into a deletion resolution."""
+    targets = [stripped for target in targets if (stripped := target.strip())]
     file_uris: dict[str, HfUri] = {}
     for target in targets:
         if target.startswith("hf://") and (uri := _parse_hf_uri_target(target)).path_in_repo:
@@ -357,16 +358,13 @@ def _resolve_deletion_targets(hf_cache_info: HFCacheInfo, targets: list[str]) ->
     revisions: set[str] = set()
     missing: list[str] = []
 
-    for raw_target in targets:
-        target = raw_target.strip()
-        if not target:
-            continue
+    for target in targets:
         lowered = target.lower()
 
         if re.fullmatch(r"[0-9a-fA-F]{40}", lowered):
             match = revision_lookup.get(lowered)
             if match is None:
-                missing.append(raw_target)
+                missing.append(target)
                 continue
             repo, revision = match
             selected[repo].add(revision)
@@ -375,7 +373,7 @@ def _resolve_deletion_targets(hf_cache_info: HFCacheInfo, targets: list[str]) ->
 
         matched_repo = repo_lookup.get(_repo_cache_id_from_target(target).lower())
         if matched_repo is None:
-            missing.append(raw_target)
+            missing.append(target)
             continue
 
         for revision in matched_repo.revisions:

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -167,11 +167,8 @@ def _parse_hf_uri_target(target: str) -> HfUri:
     return uri
 
 
-def _repo_cache_id_from_target(target: str) -> str:
-    """Return the cache id matching a repo target passed to `hf cache rm`."""
-    if not target.startswith("hf://"):
-        return target
-    uri = _parse_hf_uri_target(target)
+def _cache_id(uri: HfUri) -> str:
+    """Return the `type/id` cache id of a repo URI."""
     return f"{uri.type}/{uri.id}"
 
 
@@ -343,10 +340,8 @@ def compile_cache_sort(sort_expr: str) -> tuple[Callable[[CacheEntry], tuple[Any
 def _resolve_deletion_targets(hf_cache_info: HFCacheInfo, targets: list[str]) -> _DeletionResolution:
     """Resolve the deletion targets into a deletion resolution."""
     targets = [stripped for target in targets if (stripped := target.strip())]
-    file_uris: dict[str, HfUri] = {}
-    for target in targets:
-        if target.startswith("hf://") and (uri := _parse_hf_uri_target(target)).path_in_repo:
-            file_uris[target] = uri
+    uris = {target: _parse_hf_uri_target(target) for target in targets if target.startswith("hf://")}
+    file_uris = {target: uri for target, uri in uris.items() if uri.path_in_repo}
     if file_uris:
         if len(file_uris) != len(set(targets)):
             raise CLIError("File targets cannot be mixed with repository or revision targets.")
@@ -371,7 +366,8 @@ def _resolve_deletion_targets(hf_cache_info: HFCacheInfo, targets: list[str]) ->
             revisions.add(revision.commit_hash)
             continue
 
-        matched_repo = repo_lookup.get(_repo_cache_id_from_target(target).lower())
+        cache_id = _cache_id(uris[target]) if target in uris else target
+        matched_repo = repo_lookup.get(cache_id.lower())
         if matched_repo is None:
             missing.append(target)
             continue
@@ -394,7 +390,7 @@ def _resolve_file_targets(hf_cache_info: HFCacheInfo, file_uris: dict[str, HfUri
     files: dict[CachedFileInfo, str] = {}
     missing: list[str] = []
     for target, uri in file_uris.items():
-        repo = repo_lookup.get(f"{uri.type}/{uri.id}".lower())
+        repo = repo_lookup.get(_cache_id(uri).lower())
         if repo is None:
             missing.append(target)
             continue

--- a/src/huggingface_hub/cli/cache.py
+++ b/src/huggingface_hub/cli/cache.py
@@ -17,7 +17,7 @@ import re
 import time
 from collections import defaultdict
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Annotated, Any
 
@@ -27,10 +27,12 @@ from huggingface_hub.errors import CLIError
 
 from ..utils import (
     ANSI,
+    CachedFileInfo,
     CachedRepoInfo,
     CachedRevisionInfo,
     CacheNotFound,
     HFCacheInfo,
+    HfUri,
     _format_size,
     parse_hf_uri,
     scan_cache_dir,
@@ -52,6 +54,7 @@ class _DeletionResolution:
     revisions: frozenset[str]
     selected: dict[CachedRepoInfo, frozenset[CachedRevisionInfo]]
     missing: tuple[str, ...]
+    files: dict[CachedFileInfo, str] = field(default_factory=dict)  # selected files, mapped to their display label
 
 
 _FILTER_PATTERN = re.compile(r"^(?P<key>[a-zA-Z_]+)\s*(?P<op>==|!=|>=|<=|>|<|=)\s*(?P<value>.+)$")
@@ -151,16 +154,24 @@ def build_cache_index(
     return repo_lookup, revision_lookup
 
 
+def _parse_hf_uri_target(target: str) -> HfUri:
+    """Parse and validate an hf:// target passed to `hf cache rm`."""
+    uri = parse_hf_uri(target)
+    if not uri.is_repo:
+        raise CLIError("Only repository hf:// URIs are supported by `hf cache rm`.")
+    if uri.revision is not None:
+        raise CLIError(
+            "Revisions in hf:// URIs are not supported by `hf cache rm`. Pass a revision hash to delete a revision, "
+            "or drop '@<revision>' to delete a file from all cached revisions."
+        )
+    return uri
+
+
 def _repo_cache_id_from_target(target: str) -> str:
     """Return the cache id matching a repo target passed to `hf cache rm`."""
     if not target.startswith("hf://"):
         return target
-
-    uri = parse_hf_uri(target)
-    if not uri.is_repo:
-        raise CLIError("Only repository hf:// URIs are supported by `hf cache rm`.")
-    if uri.revision is not None or uri.path_in_repo:
-        raise CLIError("Only repo-level hf:// URIs are supported by `hf cache rm` for now.")
+    uri = _parse_hf_uri_target(target)
     return f"{uri.type}/{uri.id}"
 
 
@@ -331,6 +342,15 @@ def compile_cache_sort(sort_expr: str) -> tuple[Callable[[CacheEntry], tuple[Any
 
 def _resolve_deletion_targets(hf_cache_info: HFCacheInfo, targets: list[str]) -> _DeletionResolution:
     """Resolve the deletion targets into a deletion resolution."""
+    file_uris: dict[str, HfUri] = {}
+    for target in targets:
+        if target.startswith("hf://") and (uri := _parse_hf_uri_target(target)).path_in_repo:
+            file_uris[target] = uri
+    if file_uris:
+        if len(file_uris) != len(set(targets)):
+            raise CLIError("File targets cannot be mixed with repository or revision targets.")
+        return _resolve_file_targets(hf_cache_info, file_uris)
+
     repo_lookup, revision_lookup = build_cache_index(hf_cache_info)
 
     selected: dict[CachedRepoInfo, set[CachedRevisionInfo]] = defaultdict(set)
@@ -368,6 +388,28 @@ def _resolve_deletion_targets(hf_cache_info: HFCacheInfo, targets: list[str]) ->
         selected=frozen_selected,
         missing=tuple(missing),
     )
+
+
+def _resolve_file_targets(hf_cache_info: HFCacheInfo, file_uris: dict[str, HfUri]) -> _DeletionResolution:
+    """Select the cached files matching hf:// file URIs, in every cached revision of their repo."""
+    repo_lookup, _ = build_cache_index(hf_cache_info)
+    files: dict[CachedFileInfo, str] = {}
+    missing: list[str] = []
+    for target, uri in file_uris.items():
+        repo = repo_lookup.get(f"{uri.type}/{uri.id}".lower())
+        if repo is None:
+            missing.append(target)
+            continue
+        matches = {
+            file: f"{repo.cache_id}@{revision.commit_hash}/{uri.path_in_repo}"
+            for revision in repo.revisions
+            for file in revision.files
+            if file.file_path.relative_to(revision.snapshot_path).as_posix() == uri.path_in_repo
+        }
+        if not matches:
+            missing.append(target)
+        files.update(matches)
+    return _DeletionResolution(revisions=frozenset(), selected={}, missing=tuple(missing), files=files)
 
 
 #### Cache CLI commands
@@ -536,6 +578,7 @@ def ls(
     examples=[
         "hf cache rm model/gpt2",
         "hf cache rm hf://models/openai-community/gpt2",
+        "hf cache rm hf://models/openai-community/gpt2/model.safetensors",
         "hf cache rm <revision_hash>",
         "hf cache rm model/gpt2 --dry-run",
         "hf cache rm model/gpt2 --yes",
@@ -545,7 +588,7 @@ def rm(
     targets: Annotated[
         list[str],
         Argument(
-            help="One or more repo IDs (e.g. model/bert-base-uncased), repo-level hf:// URIs, or revision hashes to delete.",
+            help="One or more repo IDs (e.g. model/bert-base-uncased), hf:// URIs (repo or file), or revision hashes to delete.",
         ),
     ],
     cache_dir: Annotated[
@@ -569,7 +612,7 @@ def rm(
         ),
     ] = False,
 ) -> None:
-    """Remove cached repositories or revisions."""
+    """Remove cached repositories, revisions or files."""
     try:
         hf_cache_info = scan_cache_dir(cache_dir)
     except CacheNotFound as exc:
@@ -580,6 +623,28 @@ def rm(
     if resolution.missing:
         details = "\n".join(f"  - {entry}" for entry in resolution.missing)
         out.warning(f"Could not find in cache:\n{details}")
+
+    if resolution.files:
+        strategy = hf_cache_info.delete_files(*resolution.files)
+        out.text(f"About to delete {len(resolution.files)} file(s) totalling {strategy.expected_freed_size_str}.")
+        for label in sorted(resolution.files.values()):
+            out.text(f"  - {label}")
+        if dry_run:
+            out.result(
+                "Dry run: no files were deleted.",
+                dry_run=True,
+                files=len(resolution.files),
+                size=strategy.expected_freed_size_str,
+            )
+            return
+        out.confirm("Proceed with deletion?", yes=yes)
+        strategy.execute()
+        out.result(
+            f"Deleted {len(resolution.files)} file(s); freed {strategy.expected_freed_size_str}.",
+            files_deleted=len(resolution.files),
+            freed=strategy.expected_freed_size_str,
+        )
+        return
 
     if len(resolution.revisions) == 0:
         out.text("Nothing to delete.")

--- a/src/huggingface_hub/utils/_cache_manager.py
+++ b/src/huggingface_hub/utils/_cache_manager.py
@@ -258,10 +258,11 @@ class CachedRepoInfo:
 
 @dataclass(frozen=True)
 class DeleteCacheStrategy:
-    """Frozen data structure holding the strategy to delete cached revisions.
+    """Frozen data structure holding the strategy to delete cached revisions or files.
 
     This object is not meant to be instantiated programmatically but to be returned by
-    [`~utils.HFCacheInfo.delete_revisions`]. See documentation for usage example.
+    [`~utils.HFCacheInfo.delete_revisions`] or [`~utils.HFCacheInfo.delete_files`]. See
+    documentation for usage example.
 
     Args:
         expected_freed_size (`float`):
@@ -274,6 +275,9 @@ class DeleteCacheStrategy:
             Set of entire repo paths to be deleted.
         snapshots (`frozenset[Path]`):
             Set of snapshots to be deleted (directory of symlinks).
+        files (`frozenset[Path]`, *optional*):
+            Set of individual snapshot entries to be deleted. Their blobs are deleted only if
+            listed in `blobs`.
     """
 
     expected_freed_size: int
@@ -281,6 +285,7 @@ class DeleteCacheStrategy:
     refs: frozenset[Path]
     repos: frozenset[Path]
     snapshots: frozenset[Path]
+    files: frozenset[Path] = frozenset()
 
     @property
     def expected_freed_size_str(self) -> str:
@@ -306,6 +311,10 @@ class DeleteCacheStrategy:
         # Deletion order matters. Blobs are deleted in last so that the user can't end
         # up in a state where a `ref`` refers to a missing snapshot or a snapshot
         # symlink refers to a deleted blob.
+
+        # Unlink snapshot entries first: if it fails, their blobs must not be deleted.
+        for path in self.files:
+            path.unlink(missing_ok=True)
 
         # Delete entire repos
         for path in self.repos:
@@ -497,6 +506,55 @@ class HFCacheInfo:
             repos=frozenset(delete_strategy_repos),
             snapshots=frozenset(delete_strategy_snapshots),
             expected_freed_size=delete_strategy_expected_freed_size,
+        )
+
+    def delete_files(self, *files: CachedFileInfo) -> DeleteCacheStrategy:
+        """Prepare the strategy to delete individual cached files.
+
+        Only the snapshot entries are removed. A blob is deleted only if no other cached file
+        references it, so blobs shared with other revisions are kept. Refs and snapshot
+        directories are kept as well, even if a snapshot ends up empty. To delete whole
+        revisions or repos, use [`~utils.HFCacheInfo.delete_revisions`].
+
+        Example:
+        ```py
+        >>> from huggingface_hub import scan_cache_dir
+        >>> cache_info = scan_cache_dir()
+        >>> files = [
+        ...     file
+        ...     for repo in cache_info.repos
+        ...     if repo.repo_id == "org/model"
+        ...     for revision in repo.revisions
+        ...     for file in revision.files
+        ...     if file.file_name == "model-Q4_K_M.gguf"
+        ... ]
+        >>> delete_strategy = cache_info.delete_files(*files)
+        >>> print(f"Will free {delete_strategy.expected_freed_size_str}.")
+        Will free 4.9G.
+        >>> delete_strategy.execute()
+        Cache deletion done. Saved 4.9G.
+        ```
+        """
+        selected = set(files)
+        retained_blobs = {
+            file.blob_path
+            for repo in self.repos
+            for revision in repo.revisions
+            for file in revision.files
+            if file not in selected
+        }
+        blobs_to_unlink = {
+            file.blob_path: file.size_on_disk for file in selected if file.blob_path not in retained_blobs
+        }
+        file_paths = frozenset(file.file_path for file in selected)
+        return DeleteCacheStrategy(
+            expected_freed_size=sum(blobs_to_unlink.values()),
+            # Files stored directly in the snapshot (no symlink) are already removed with the entry.
+            blobs=frozenset(blobs_to_unlink.keys() - file_paths),
+            refs=frozenset(),
+            repos=frozenset(),
+            snapshots=frozenset(),
+            files=file_paths,
         )
 
     def export_as_table(self, *, verbosity: int = 0) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,7 +50,7 @@ def runner() -> CliRunner:
 
 
 def _make_revision(
-    commit_hash: str, *, refs: Optional[set[str]] = None, files: frozenset[CachedFileInfo] = frozenset()
+    commit_hash: str, *, refs: set[str] | None = None, files: frozenset[CachedFileInfo] = frozenset()
 ) -> CachedRevisionInfo:
     return CachedRevisionInfo(
         commit_hash=commit_hash,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,12 +49,14 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
-def _make_revision(commit_hash: str, *, refs: Optional[set[str]] = None) -> CachedRevisionInfo:
+def _make_revision(
+    commit_hash: str, *, refs: Optional[set[str]] = None, files: frozenset[CachedFileInfo] = frozenset()
+) -> CachedRevisionInfo:
     return CachedRevisionInfo(
         commit_hash=commit_hash,
         snapshot_path=Path(f"/tmp/{commit_hash}"),
         size_on_disk=0,
-        files=frozenset(),
+        files=files,
         refs=frozenset(refs or set()),
         last_modified=0.0,
     )
@@ -221,23 +223,54 @@ class TestCacheCommand:
         hf_cache_info.delete_revisions.assert_called_once_with(revision.commit_hash)
         strategy.execute.assert_called_once_with()
 
+    def test_rm_file_uri_executes_strategy(self, runner: CliRunner) -> None:
+        commit_hash = "c" * 40
+        file = CachedFileInfo(
+            file_name="config.json",
+            file_path=Path(f"/tmp/{commit_hash}/config.json"),
+            blob_path=Path("/tmp/blobs/abc"),
+            size_on_disk=0,
+            blob_last_accessed=0.0,
+            blob_last_modified=0.0,
+        )
+        revision = _make_revision(commit_hash, files=frozenset({file}))
+        repo = _make_repo("user/model", revisions=[revision])
+
+        strategy = Mock()
+        strategy.expected_freed_size_str = "0B"
+
+        hf_cache_info = Mock()
+        hf_cache_info.delete_files.return_value = strategy
+
+        with (
+            patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=hf_cache_info),
+            patch("huggingface_hub.cli.cache.build_cache_index", return_value=({"model/user/model": repo}, {})),
+        ):
+            result = runner.invoke(app, ["cache", "rm", "hf://models/user/model/config.json", "--yes"])
+
+        assert result.exit_code == 0
+        assert f"model/user/model@{commit_hash}/config.json" in result.output
+        hf_cache_info.delete_files.assert_called_once_with(file)
+        strategy.execute.assert_called_once_with()
+
     @pytest.mark.parametrize(
-        "target",
+        "targets, message",
         [
-            "hf://models/openai-community/gpt2@main",
-            "hf://models/openai-community/gpt2/config.json",
+            (["hf://models/openai-community/gpt2@main"], "Revisions in hf:// URIs are not supported"),
+            (["hf://models/openai-community/gpt2@main/config.json"], "Revisions in hf:// URIs are not supported"),
+            (["hf://models/openai-community/gpt2/config.json", "model/openai-community/gpt2"], "cannot be mixed"),
         ],
     )
-    def test_rm_hf_uri_rejects_revisions_and_paths(self, runner: CliRunner, target: str) -> None:
+    def test_rm_hf_uri_rejects_invalid_targets(self, runner: CliRunner, targets: list[str], message: str) -> None:
         with (
             patch("huggingface_hub.cli.cache.scan_cache_dir"),
             patch("huggingface_hub.cli.cache.build_cache_index", return_value=({}, {})),
         ):
-            result = runner.invoke(app, ["cache", "rm", target])
+            result = runner.invoke(app, ["cache", "rm", *targets])
 
         assert result.exit_code == 1
         assert isinstance(result.exception, CLIError)
-        assert "Only repo-level hf:// URIs are supported" in str(result.exception)
+        assert message in str(result.exception)
 
     def test_rm_hf_uri_rejects_buckets(self, runner: CliRunner) -> None:
         with (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -223,7 +223,8 @@ class TestCacheCommand:
         hf_cache_info.delete_revisions.assert_called_once_with(revision.commit_hash)
         strategy.execute.assert_called_once_with()
 
-    def test_rm_file_uri_executes_strategy(self, runner: CliRunner) -> None:
+    @pytest.mark.parametrize("target", ["hf://models/user/model/config.json", " hf://models/user/model/config.json "])
+    def test_rm_file_uri_executes_strategy(self, runner: CliRunner, target: str) -> None:
         commit_hash = "c" * 40
         file = CachedFileInfo(
             file_name="config.json",
@@ -246,7 +247,7 @@ class TestCacheCommand:
             patch("huggingface_hub.cli.cache.scan_cache_dir", return_value=hf_cache_info),
             patch("huggingface_hub.cli.cache.build_cache_index", return_value=({"model/user/model": repo}, {})),
         ):
-            result = runner.invoke(app, ["cache", "rm", "hf://models/user/model/config.json", "--yes"])
+            result = runner.invoke(app, ["cache", "rm", target, "--yes"])
 
         assert result.exit_code == 0
         assert f"model/user/model@{commit_hash}/config.json" in result.output

--- a/tests/test_utils_cache.py
+++ b/tests/test_utils_cache.py
@@ -581,6 +581,61 @@ class TestDeleteRevisionsDryRun:
         assert records[0].message == "Revision(s) not found - cannot delete them: abcdef123456789"
 
 
+class TestDeleteFilesDryRun:
+    cache_info: Mock  # Mocked HFCacheInfo
+
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
+        """Set up fake cache scan report: two revisions sharing one blob."""
+        repo_A_path = Path("repo_A")
+
+        def make_file(revision: str, name: str, blob: str, size: int) -> Mock:
+            file = Mock()
+            file.file_path = repo_A_path / "snapshots" / revision / name
+            file.blob_path = repo_A_path / "blobs" / blob
+            file.size_on_disk = size
+            return file
+
+        self.main_shared = make_file("rev_main", "shared.bin", "shared_hash", 10)
+        self.main_only = make_file("rev_main", "main_only.bin", "main_only_hash", 100)
+        self.main_direct = make_file("rev_main", "direct.bin", "direct.bin", 1000)
+        self.main_direct.blob_path = self.main_direct.file_path  # no symlink: data lives in the snapshot
+        self.detached_shared = make_file("rev_detached", "shared.bin", "shared_hash", 10)
+
+        rev_main = Mock()
+        rev_main.files = {self.main_shared, self.main_only, self.main_direct}
+        rev_detached = Mock()
+        rev_detached.files = {self.detached_shared}
+
+        repo_A = Mock()
+        repo_A.revisions = {rev_main, rev_detached}
+
+        cache_info = Mock()
+        cache_info.repos = [repo_A]
+        self.cache_info = cache_info
+
+    def test_delete_files_keeps_shared_blob(self) -> None:
+        strategy = HFCacheInfo.delete_files(self.cache_info, self.main_shared, self.main_only, self.main_direct)
+        expected = DeleteCacheStrategy(
+            expected_freed_size=1100,
+            blobs={Path("repo_A/blobs/main_only_hash")},  # "shared_hash" still used by the detached revision
+            refs=set(),
+            repos=set(),
+            snapshots=set(),
+            files={
+                Path("repo_A/snapshots/rev_main/shared.bin"),
+                Path("repo_A/snapshots/rev_main/main_only.bin"),
+                Path("repo_A/snapshots/rev_main/direct.bin"),
+            },
+        )
+        assert strategy == expected
+
+    def test_delete_files_in_all_revisions_frees_blob(self) -> None:
+        strategy = HFCacheInfo.delete_files(self.cache_info, self.main_shared, self.detached_shared)
+        assert strategy.expected_freed_size == 10
+        assert strategy.blobs == {Path("repo_A/blobs/shared_hash")}
+
+
 class TestDeleteStrategyExecute:
     def test_execute(self, tmp_path) -> None:
         # Repo folders
@@ -612,15 +667,20 @@ class TestDeleteStrategyExecute:
 
         snapshot_1.mkdir(parents=True)
         snapshot_2.mkdir()
+        file_1 = snapshot_1 / "file_1"
+        file_2 = snapshot_1 / "file_2"
+        file_1.touch()
+        file_2.touch()
 
         # Execute deletion
-        # Delete repo_A + keep only blob_1, main ref and snapshot_1 in repo_B.
+        # Delete repo_A + keep only blob_1, main ref, snapshot_1 and file_1 in repo_B.
         DeleteCacheStrategy(
             expected_freed_size=123456,
             blobs={blob_2, blob_3},
             refs={refs_pr_1_path},
             repos={repo_A_path},
             snapshots={snapshot_2},
+            files={file_2},
         ).execute()
 
         # Repo A deleted
@@ -636,9 +696,11 @@ class TestDeleteStrategyExecute:
         assert refs_main_path.exists()
         assert not refs_pr_1_path.exists()
 
-        # Only `snapshot_1` remains
+        # Only `snapshot_1` remains, without `file_2`
         assert snapshot_1.exists()
         assert not snapshot_2.exists()
+        assert file_1.exists()
+        assert not file_2.exists()
 
 
 class TestTryDeletePath:


### PR DESCRIPTION
Follow-up to #4235. `hf cache rm` now accepts `hf://` file URIs to remove a single cached file, typically one GGUF quantization, without deleting the whole repo. Closes #4124.

## Summary

- `hf cache rm hf://models/<repo_id>/<path>` removes the file from every cached revision of the repo. The blob is deleted only if no other cached file still references it. Refs and snapshot folders are kept.
- Exact paths only: no folders, no globs. File targets can't be mixed with repo or revision targets in the same call. `@revision` in `hf://` URIs is still rejected, for repos and files alike, with a hint on what to do instead.
- New `HFCacheInfo.delete_files(*files)` next to `delete_revisions`, returning the usual `DeleteCacheStrategy`. The strategy gets a `files` field: snapshot entries that `execute()` unlinks first, before any blob is deleted.
- Blob accounting is a `blobs_to_unlink` map like in `delete_revisions`, so the shared blob store (#4498) can plug in later with a two-line change.

Manual test on a temp cache with two revisions sharing the Q4 blob:

```text
$ hf cache ls --revisions
ID              REVISION                             SIZE LAST_MODIFIED     REFS
--------------- ----------------------------------- ----- ----------------- ----
model/org/model aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa... 12.6M a few seconds ago main
model/org/model bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb...  4.2M a few seconds ago

$ hf cache rm hf://models/org/model/model-Q4_K_M.gguf --dry-run
About to delete 2 file(s) totalling 4.2M.
  - model/org/model@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/model-Q4_K_M.gguf
  - model/org/model@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/model-Q4_K_M.gguf
✓ Dry run: no files were deleted.

$ hf cache rm hf://models/org/model/model-Q4_K_M.gguf -y
About to delete 2 file(s) totalling 4.2M.
  - model/org/model@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/model-Q4_K_M.gguf
  - model/org/model@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/model-Q4_K_M.gguf
Cache deletion done. Saved 4.2M.
✓ Deleted 2 file(s); freed 4.2M.

$ hf cache ls --revisions
ID              REVISION                             SIZE LAST_MODIFIED     REFS
--------------- ------------------------------------ ---- ----------------- ----
model/org/model aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa... 8.4M a few seconds ago main
model/org/model bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb...  0.0 a few seconds ago

$ hf cache rm hf://models/org/model@main/model-Q8_0.gguf
Error: Revisions in hf:// URIs are not supported by `hf cache rm`. Pass a revision hash to delete a revision, or drop '@<revision>' to delete a file from all cached revisions.

$ hf cache rm hf://models/org/model/model-Q8_0.gguf model/org/model
Error: File targets cannot be mixed with repository or revision targets.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes local cache deletion semantics and filesystem unlink order; mistakes could remove wanted blobs, though confirmation/dry-run and shared-blob retention limit impact.
> 
> **Overview**
> **`hf cache rm`** can now target a single cached file via an `hf://` file URI (e.g. one GGUF quantization), removing that path from every cached revision while keeping refs and snapshot folders; blobs are dropped only when nothing else references them.
> 
> The CLI resolves file URIs separately from repo/revision targets (they cannot be mixed), rejects `@revision` on `hf://` inputs with clearer hints, and uses a new **`HFCacheInfo.delete_files`** path that returns **`DeleteCacheStrategy`** with a **`files`** set—`execute()` unlinks those snapshot entries before deleting unshared blobs. Docs and tests cover dry-run output, shared-blob behavior, and invalid target combinations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a7caa52e930f9631afa4a4e260361ed4d680c74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->