### PR TITLE
[CLI] Fix truncated command descriptions in the CLI reference

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -27,26 +27,26 @@ $ hf [OPTIONS] [COMMAND] [ARGS]...
 * `buckets`: Commands to interact with buckets.
 * `cache`: Manage local cache directory.
 * `collections`: Interact with collections on the Hub.
-* `cp`: Copy files between local paths,...
+* `cp`: Copy files between local paths, repositories, and buckets.
 * `datasets`: Interact with datasets on the Hub.
-* `discussions`: Manage discussions and pull requests on...
+* `discussions`: Manage discussions and pull requests on the Hub.
 * `download`: Download files from the Hub.
 * `endpoints`: Manage Hugging Face Inference Endpoints.
 * `env`: Print information about the environment.
 * `extensions`: Manage hf CLI extensions. [alias: ext]
 * `jobs`: Run and manage Jobs on the Hub.
-* `lfs-enable-largefiles`: Configure your repository to enable upload...
-* `lfs-multipart-upload`: Internal git-lfs custom transfer agent for...
+* `lfs-enable-largefiles`: Configure your repository to enable upload of files > 5GB.
+* `lfs-multipart-upload`: Internal git-lfs custom transfer agent for multipart uploads.
 * `models`: Interact with models on the Hub.
 * `papers`: Interact with papers on the Hub.
 * `repos`: Manage repos on the Hub. [alias: repo]
-* `sandbox`: Run and manage experimental sandboxes on...
+* `sandbox`: Run and manage experimental sandboxes on Hugging Face Jobs.
 * `skills`: Manage skills for AI assistants.
 * `spaces`: Interact with spaces on the Hub.
-* `sync`: Sync files between local directory and a...
+* `sync`: Sync files between local directory and a bucket.
 * `update`: Update the `hf` CLI to the latest version.
 * `upload`: Upload a file or a folder to the Hub.
-* `upload-large-folder`: [Deprecated] Upload a large folder to the...
+* `upload-large-folder`: [Deprecated] Upload a large folder to the Hub.
 * `version`: Print information about the hf version.
 * `webhooks`: Manage webhooks on the Hub.
 
@@ -67,11 +67,11 @@ $ hf auth [OPTIONS] COMMAND [ARGS]...
 **Commands**:
 
 * `list`: List all stored access tokens. [alias: ls]
-* `login`: Login from your browser, or using a token...
+* `login`: Login from your browser, or using a token from huggingface.co/settings/tokens.
 * `logout`: Logout from a specific token.
 * `switch`: Switch between access tokens.
 * `token`: Print the current access token to stdout.
-* `whoami`: Find out which huggingface.co account you...
+* `whoami`: Find out which huggingface.co account you are logged in as.
 
 ### `hf auth list`
 
@@ -234,15 +234,15 @@ $ hf buckets [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `cp`: Copy files between local paths,...
+* `cp`: Copy files between local paths, repositories, and buckets.
 * `create`: Create a new bucket.
 * `delete`: Delete a bucket.
 * `info`: Get info about a bucket.
 * `list`: List buckets or files in a bucket. [alias: ls]
-* `move`: Move (rename) a bucket to a new name or...
+* `move`: Move (rename) a bucket to a new name or namespace.
 * `remove`: Remove files from a bucket. [alias: rm]
 * `settings`: Update bucket settings (visibility).
-* `sync`: Sync files between local directory and a...
+* `sync`: Sync files between local directory and a bucket.
 
 ### `hf buckets cp`
 
@@ -588,9 +588,9 @@ $ hf cache [OPTIONS] COMMAND [ARGS]...
 **Commands**:
 
 * `list`: List cached repositories or revisions. [alias: ls]
-* `prune`: Remove detached revisions and incomplete...
+* `prune`: Remove detached revisions and incomplete downloads from the cache.
 * `rm`: Remove cached repositories or revisions.
-* `verify`: Verify checksums for a single repo...
+* `verify`: Verify checksums for a single repo revision from cache or a local directory.
 
 ### `hf cache list`
 
@@ -1044,12 +1044,12 @@ $ hf datasets [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `card`: Get the dataset card (README) for a...
+* `card`: Get the dataset card (README) for a dataset on the Hub.
 * `info`: Get info about a dataset on the Hub.
 * `leaderboard`: List model scores from a dataset leaderboard.
-* `list`: List datasets on the Hub, or files in a... [alias: ls]
-* `parquet`: List parquet file URLs available for a...
-* `sql`: Execute a raw SQL query with DuckDB...
+* `list`: List datasets on the Hub, or files in a dataset repo. [alias: ls]
+* `parquet`: List parquet file URLs available for a dataset.
+* `sql`: Execute a raw SQL query with DuckDB against dataset parquet URLs.
 
 ### `hf datasets card`
 
@@ -1267,9 +1267,9 @@ $ hf discussions [OPTIONS] COMMAND [ARGS]...
 
 * `close`: Close a discussion or pull request.
 * `comment`: Comment on a discussion or pull request.
-* `create`: Create a new discussion or pull request on...
+* `create`: Create a new discussion or pull request on a repo.
 * `diff`: Show the diff of a pull request.
-* `edit`: Edit an existing comment on a discussion...
+* `edit`: Edit an existing comment on a discussion or pull request.
 * `info`: Get info about a discussion or pull request.
 * `list`: List discussions and pull requests on a repo. [alias: ls]
 * `merge`: Merge a pull request.
@@ -1654,12 +1654,12 @@ $ hf endpoints [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `catalog`: Interact with the Inference Endpoints...
+* `catalog`: Interact with the Inference Endpoints catalog.
 * `delete`: Delete an Inference Endpoint permanently.
-* `deploy`: Deploy an Inference Endpoint from a Hub...
+* `deploy`: Deploy an Inference Endpoint from a Hub repository.
 * `describe`: Get information about an existing endpoint.
-* `hardware`: List the hardware available to deploy an...
-* `list`: Lists all Inference Endpoints for the... [alias: ls]
+* `hardware`: List the hardware available to deploy an Inference Endpoint on.
+* `list`: Lists all Inference Endpoints for the given namespace. [alias: ls]
 * `list-catalog`: List available Catalog models.
 * `pause`: Pause an Inference Endpoint.
 * `resume`: Resume an Inference Endpoint.
@@ -1682,7 +1682,7 @@ $ hf endpoints catalog [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `deploy`: Deploy an Inference Endpoint from the...
+* `deploy`: Deploy an Inference Endpoint from the Model Catalog.
 * `list`: List available Catalog models. [alias: ls]
 
 #### `hf endpoints catalog deploy`
@@ -2095,11 +2095,11 @@ $ hf extensions [OPTIONS] COMMAND [ARGS]...
 **Commands**:
 
 * `exec`: Execute an installed extension.
-* `install`: Install an extension from a public GitHub...
+* `install`: Install an extension from a public GitHub repository.
 * `list`: List installed extension commands. [alias: ls]
 * `remove`: Remove an installed extension. [alias: rm]
-* `search`: Search extensions available on GitHub...
-* `update`: Update installed extension(s) to their...
+* `search`: Search extensions available on GitHub (tagged with 'hf-extension' topic).
+* `update`: Update installed extension(s) to their latest version.
 
 ### `hf extensions exec`
 
@@ -2276,16 +2276,16 @@ $ hf jobs [OPTIONS] COMMAND [ARGS]...
 
 * `cancel`: Cancel a Job
 * `hardware`: List available hardware options for Jobs
-* `inspect`: Display detailed information on one or...
+* `inspect`: Display detailed information on one or more Jobs
 * `labels`: Update labels on a Job.
 * `list`: List Jobs. [alias: ls, ps]
 * `logs`: Fetch the logs of a Job.
 * `run`: Run a Job.
 * `scheduled`: Create and manage scheduled Jobs on the Hub.
 * `ssh`: SSH into a running Job.
-* `stats`: Fetch the resource usage statistics and...
-* `uv`: Run UV scripts (Python with inline...
-* `wait`: Wait for one or more Jobs to reach a...
+* `stats`: Fetch the resource usage statistics and metrics of Jobs
+* `uv`: Run UV scripts (Python with inline dependencies) on HF infrastructure.
+* `wait`: Wait for one or more Jobs to reach a terminal state.
 
 ### `hf jobs cancel`
 
@@ -2541,13 +2541,13 @@ $ hf jobs scheduled [OPTIONS] COMMAND [ARGS]...
 **Commands**:
 
 * `delete`: Delete a scheduled Job.
-* `inspect`: Display detailed information on one or...
+* `inspect`: Display detailed information on one or more scheduled Jobs
 * `labels`: Update labels on a scheduled Job.
 * `list`: List scheduled Jobs. [alias: ls, ps]
 * `resume`: Resume (unpause) a scheduled Job.
 * `run`: Schedule a Job.
 * `suspend`: Suspend (pause) a scheduled Job.
-* `trigger`: Trigger a scheduled Job to run immediately...
+* `trigger`: Trigger a scheduled Job to run immediately (does not change the schedule).
 * `uv`: Schedule UV scripts on HF infrastructure.
 
 #### `hf jobs scheduled delete`
@@ -2818,7 +2818,7 @@ $ hf jobs scheduled uv [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `run`: Run a UV script (local file or URL) on HF...
+* `run`: Run a UV script (local file or URL) on HF infrastructure
 
 ##### `hf jobs scheduled uv run`
 
@@ -2947,7 +2947,7 @@ $ hf jobs uv [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `run`: Run a UV script (local file or URL) on HF...
+* `run`: Run a UV script (local file or URL) on HF infrastructure
 
 #### `hf jobs uv run`
 
@@ -3090,9 +3090,9 @@ $ hf models [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `card`: Get the model card (README) for a model on...
+* `card`: Get the model card (README) for a model on the Hub.
 * `info`: Get info about a model on the Hub.
-* `list`: List models on the Hub, or files in a... [alias: ls]
+* `list`: List models on the Hub, or files in a model repo. [alias: ls]
 
 ### `hf models card`
 
@@ -3368,13 +3368,13 @@ $ hf repos [OPTIONS] [COMMAND] [ARGS]...
 **Commands**:
 
 * `branch`: Manage branches for a repo on the Hub.
-* `cp`: Copy files between local paths,...
+* `cp`: Copy files between local paths, repositories, and buckets.
 * `create`: Create a new repo on the Hub.
 * `delete`: Delete a repo from the Hub.
 * `delete-files`: Delete files from a repo on the Hub.
-* `duplicate`: Duplicate a repo on the Hub (model,...
-* `list`: List all repos (models, datasets, spaces,... [alias: ls]
-* `move`: Move a repository from a namespace to...
+* `duplicate`: Duplicate a repo on the Hub (model, dataset, or Space).
+* `list`: List all repos (models, datasets, spaces, buckets) with storage info. [alias: ls]
+* `move`: Move a repository from a namespace to another namespace.
 * `settings`: Update the settings of a repository.
 * `tag`: Manage tags for a repo on the Hub.
 
@@ -3876,13 +3876,13 @@ $ hf sandbox [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `cp`: Copy a file between the local machine and...
-* `create`: Create a sandbox: a dedicated VM by...
+* `cp`: Copy a file between the local machine and a sandbox (docker-style).
+* `create`: Create a sandbox: a dedicated VM by default, or a cheap shared one with `--pool`.
 * `exec`: Run a command in a sandbox, streaming output.
-* `kill`: Terminate a sandbox, a whole shared host,...
-* `pool`: Warm host VM pools and spawn experimental...
-* `process`: List and stop background processes running...
-* `spawn`: Start a long-running command in the...
+* `kill`: Terminate a sandbox, a whole shared host, or everything (--all).
+* `pool`: Warm host VM pools and spawn experimental shared sandboxes for workloads within the same trust boundary.
+* `process`: List and stop background processes running in a sandbox.
+* `spawn`: Start a long-running command in the background and return its pid (don't wait).
 
 ### `hf sandbox cp`
 
@@ -4046,9 +4046,9 @@ $ hf sandbox pool [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `create`: Warm a pool: boot one host VM now, tagged...
-* `delete`: Terminate every host VM of a pool (and... [alias: rm]
-* `ls`: List running sandbox pools (grouped from... [alias: list]
+* `create`: Warm a pool: boot one host VM now, tagged so it can be found later by its pool id.
+* `delete`: Terminate every host VM of a pool (and therefore all its sandboxes). [alias: rm]
+* `ls`: List running sandbox pools (grouped from their host VMs). [alias: list]
 
 #### `hf sandbox pool create`
 
@@ -4153,8 +4153,8 @@ $ hf sandbox process [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `kill`: Stop a background process running in a...
-* `ls`: List the background processes running in a... [alias: list]
+* `kill`: Stop a background process running in a sandbox.
+* `ls`: List the background processes running in a sandbox (started with `hf sandbox spawn`). [alias: list]
 
 #### `hf sandbox process kill`
 
@@ -4265,10 +4265,10 @@ $ hf skills [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `add`: Install a Hugging Face skill for an AI...
-* `list`: List available skills from the Hugging... [alias: ls]
-* `preview`: Print the generated `hf-cli` SKILL.md to...
-* `update`: Update installed Hugging Face marketplace...
+* `add`: Install a Hugging Face skill for an AI assistant.
+* `list`: List available skills from the Hugging Face marketplace. [alias: ls]
+* `preview`: Print the generated `hf-cli` SKILL.md to stdout.
+* `update`: Update installed Hugging Face marketplace skills.
 
 ### `hf skills add`
 
@@ -4395,21 +4395,21 @@ $ hf spaces [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `card`: Get the Space card (README) for a Space on...
+* `card`: Get the Space card (README) for a Space on the Hub.
 * `dev-mode`: Enable or disable dev mode on a Space.
 * `hardware`: List available hardware options for Spaces.
-* `hot-reload`: Hot-reload any Python file of a Space...
+* `hot-reload`: Hot-reload any Python file of a Space without a full rebuild + restart.
 * `info`: Get info about a space on the Hub.
-* `list`: List spaces on the Hub, or files in a... [alias: ls]
+* `list`: List spaces on the Hub, or files in a space repo. [alias: ls]
 * `logs`: Fetch the run or build logs of a Space.
 * `pause`: Pause a Space.
 * `restart`: Restart a Space.
-* `search`: Search spaces on the Hub using semantic...
+* `search`: Search spaces on the Hub using semantic search.
 * `secrets`: Manage secrets for a Space on the Hub.
 * `settings`: Update the settings of a Space.
 * `ssh`: SSH into a Space's Dev Mode container.
 * `templates`: List the available Space templates.
-* `variables`: Manage environment variables for a Space...
+* `variables`: Manage environment variables for a Space on the Hub.
 * `volumes`: Manage volumes for a Space on the Hub.
 * `wait`: Wait for a Space to finish building/starting.
 
@@ -4967,7 +4967,7 @@ $ hf spaces variables [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `add`: Add or update environment variables for a...
+* `add`: Add or update environment variables for a Space.
 * `delete`: Remove an environment variable from a Space.
 * `list`: List environment variables for a Space. [alias: ls]
 

--- a/tests/test_generate_cli_reference.py
+++ b/tests/test_generate_cli_reference.py
@@ -1,4 +1,6 @@
-from utils.generate_cli_reference import _normalize_command_aliases
+import click
+
+from utils.generate_cli_reference import _normalize_command_aliases, get_docs_for_click
 
 
 def test_normalize_nested_aliases_in_usage_lines() -> None:
@@ -39,3 +41,19 @@ $ hf extensions | ext list | ls [OPTIONS]
 
     assert "$ hf extensions list [OPTIONS]" in normalized
     assert "$ hf extensions | ext list [OPTIONS]" not in normalized
+
+
+def test_short_help_is_not_truncated() -> None:
+    @click.group()
+    def cli() -> None: ...
+
+    @cli.command()
+    def verify() -> None:
+        """Verify checksums for a single repo revision from cache or a local directory.
+
+        More details here.
+        """
+
+    docs = get_docs_for_click(obj=cli, ctx=click.Context(cli, info_name="hf"), name="hf")
+
+    assert "* `verify`: Verify checksums for a single repo revision from cache or a local directory.\n" in docs

--- a/utils/generate_cli_reference.py
+++ b/utils/generate_cli_reference.py
@@ -1,5 +1,6 @@
 import argparse
 import re
+import sys
 from difflib import unified_diff
 from pathlib import Path
 
@@ -63,7 +64,8 @@ def get_docs_for_click(
         if commands:
             docs += "**Commands**:\n\n"
             for _, sub in commands:
-                short_help = sub.get_short_help_str()
+                # Click's default limit is 45 chars; keep the full first sentence like `hf --help` does.
+                short_help = sub.get_short_help_str(limit=sys.maxsize)
                 docs += f"* `{sub.name}`" + (f": {short_help}" if short_help else "") + "\n"
             docs += "\n"
         for _, sub in commands:


### PR DESCRIPTION
## Summary

- The generated CLI reference cut command descriptions at 45 characters with a trailing `...`. 61 commands were affected, e.g. `hf cache rm`, `hf cache verify`, `hf auth login`.
- Cause: `utils/generate_cli_reference.py` built the **Commands** bullets with Click's `get_short_help_str()`, whose default `limit` is 45. The terminal help in `_cli_utils.py` calls the same function with the terminal width, so `hf cache --help` was already fine and only `cli.md` was truncated.
- Fix: pass `limit=sys.maxsize`. Click still stops at the end of the first sentence, so each bullet stays one sentence and matches what `hf <group> --help` prints. I went with this rather than adding `short_help=` to every command, which would mean touching 61 decorators for the same result.
- Regenerated `docs/source/en/package_reference/cli.md` (description bullets only, nothing else changed) and added a small regression test.

Before / after in `cli.md`:

```diff
-* `prune`: Remove detached revisions and incomplete...
-* `rm`: Remove cached repositories, revisions or...
-* `verify`: Verify checksums for a single repo...
+* `prune`: Remove detached revisions and incomplete downloads from the cache.
+* `rm`: Remove cached repositories, revisions or files.
+* `verify`: Verify checksums for a single repo revision from cache or a local directory.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doc-generation only; no runtime CLI behavior changes beyond regenerated markdown.
> 
> **Overview**
> Fixes **truncated command blurbs** in the auto-generated CLI reference (`cli.md`). The generator was calling Click's `get_short_help_str()` with the default **45-character** limit, so dozens of **Commands** bullets ended with `...` even though terminal `hf <group> --help` already showed fuller text.
> 
> **`generate_cli_reference.py`** now passes `limit=sys.maxsize` when building those bullets (still one sentence per command, matching Click's first-sentence behavior). **`cli.md`** was regenerated so descriptions are complete. A regression test **`test_short_help_is_not_truncated`** locks in the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d53185078594623532c0a9206aa676fc07225b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->