### PR TITLE
[Sandbox] Preserve terminal command results

### DIFF
--- a/src/huggingface_hub/_sandbox.py
+++ b/src/huggingface_hub/_sandbox.py
@@ -829,6 +829,8 @@ class Sandbox:
                         timed_out=event.get("timed_out", False),
                         duration_ms=event.get("duration_ms", 0),
                     )
+                    # Exit is terminal: a truncated HTTP tail must not mask the command result.
+                    break
         if result is None:
             raise SandboxError("connection lost while running command")
         if check and (result.exit_code != 0 or result.timed_out):

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -3,6 +3,7 @@ import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 
 import huggingface_hub._sandbox as sandbox_mod
@@ -70,6 +71,42 @@ def _make_sandbox(base_url: str) -> Sandbox:
     """A dedicated sandbox (one job) wired to a local server."""
     server = _make_server(base_url)
     return Sandbox(id="job123", server=server, local_id=None, owns_sandbox=True, owns_server=True)
+
+
+class _TerminalStream(httpx.SyncByteStream):
+    """Offline response body with an optional transport failure after its chunks."""
+
+    def __init__(self, chunks, error=None):
+        self.chunks = chunks
+        self.error = error
+        self.closed = False
+        self.reached_tail = False
+
+    def __iter__(self):
+        yield from self.chunks
+        self.reached_tail = True
+        if self.error is not None:
+            raise self.error
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def terminal_stream(monkeypatch):
+    sandbox = _make_sandbox("https://sandbox.example")
+    sandbox._server._client.close()
+
+    def setup(chunks, error=None):
+        stream = _TerminalStream(chunks, error)
+        response = httpx.Response(200, stream=stream)
+        handler = MagicMock(return_value=response)
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        monkeypatch.setattr(sandbox._server, "_client", client)
+        return sandbox, stream, response, handler
+
+    yield setup
+    sandbox._server.close()
 
 
 class _FakeServer(BaseHTTPRequestHandler):
@@ -663,3 +700,64 @@ class TestPoolCacheIntegration:
         with pytest.raises(SandboxError, match="No running host found"):
             pool.create()
         assert read_pool_cache("pool-ghost") is None  # cleared
+
+
+@pytest.mark.parametrize("exit_code,timed_out", [(0, False), (3, False), (0, True), (None, True)])
+@pytest.mark.parametrize("check", [True, False])
+@pytest.mark.parametrize("split", [True, False])
+@pytest.mark.parametrize("tail_error", [None, httpx.RemoteProtocolError("incomplete chunked read")])
+def test_terminal_stream_result(terminal_stream, exit_code, timed_out, check, split, tail_error):
+    events = [
+        {"event": "stdout", "data": "out"},
+        {"event": "ping"},
+        {"event": "stderr", "data": "err"},
+        {"event": "exit", "exit_code": exit_code, "timed_out": timed_out, "signal": 15, "duration_ms": 5},
+    ]
+    body = b"\n" + b"".join((json.dumps(event) + "\n").encode() for event in events)
+    chunks = [body[i : i + 1] for i in range(len(body))] if split else [body]
+    sandbox, stream, response, handler = terminal_stream(chunks, tail_error)
+    on_stdout, on_stderr = MagicMock(), MagicMock()
+    if check and (exit_code != 0 or timed_out):
+        with pytest.raises(SandboxCommandError) as exc:
+            sandbox.run("example", check=check, on_stdout=on_stdout, on_stderr=on_stderr)
+        result = exc.value.result
+    else:
+        result = sandbox.run("example", check=check, on_stdout=on_stdout, on_stderr=on_stderr)
+    assert (result.exit_code, result.timed_out, result.signal, result.duration_ms) == (exit_code, timed_out, 15, 5)
+    assert (result.stdout, result.stderr) == ("out", "err")
+    on_stdout.assert_called_once_with("out")
+    on_stderr.assert_called_once_with("err")
+    assert response.is_closed and stream.closed
+    assert not stream.reached_tail
+    handler.assert_called_once()
+    assert handler.call_args.args[0].method == "POST"
+
+
+@pytest.mark.parametrize(
+    "body,error,expected",
+    [
+        (b'{"event":"stdout","data":"partial"}\n', None, SandboxError),
+        (b'{"event":"stdout","data":"partial"}\n', httpx.RemoteProtocolError("truncated"), httpx.RemoteProtocolError),
+        (b'{"event":"exit",', None, json.JSONDecodeError),
+        (b'{"event":"exit",', httpx.RemoteProtocolError("truncated"), httpx.RemoteProtocolError),
+        (b"{invalid}\n", None, json.JSONDecodeError),
+        (b'{"event":"exit"}\n', None, KeyError),
+    ],
+)
+def test_terminal_stream_failure_before_result(terminal_stream, body, error, expected):
+    sandbox, stream, response, handler = terminal_stream([body], error)
+    with pytest.raises(expected):
+        sandbox.run("example")
+    assert response.is_closed and stream.closed
+    handler.assert_called_once()
+
+
+def test_terminal_stream_ignores_events_after_exit(terminal_stream):
+    sandbox, stream, response, handler = terminal_stream(
+        [b'{"event":"exit","exit_code":0}\n{"event":"stdout","data":"late"}\n{invalid}\n']
+    )
+    callback = MagicMock()
+    assert sandbox.run("example", on_stdout=callback).stdout == ""
+    callback.assert_not_called()
+    assert response.is_closed and stream.closed
+    handler.assert_called_once()


### PR DESCRIPTION
Closes #4850.

Stop after constructing the terminal result so a broken HTTP tail cannot mask it; keep response closure and existing exit/timeout checks, with no replay or new event validation.

Validation: 39 offline MockTransport cases pass (33 failed before the fix), covering tails, split lines, callbacks, closure, and pre-exit failures; `make style` and `make quality` pass. No live Sandbox execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to streaming exec completion in the experimental Sandbox API, with broad offline test coverage.
> 
> **Overview**
> **Fixes `Sandbox.run` losing a finished command when the `/exec` NDJSON stream breaks after the `exit` event** (e.g. incomplete chunked read).
> 
> After building `SandboxCommandResult` from the `exit` event, the client **stops reading the stream** so a bad HTTP tail cannot replace the result with `SandboxError`, parse errors, or spurious stdout callbacks. Existing `check`/timeout behavior and response cleanup are unchanged.
> 
> Adds **offline `httpx` MockTransport tests** for byte-split streams, post-exit transport errors, pre-exit failures, and trailing events after exit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1c01f06919a5e57e57b6d78bc3d7e4de81534e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->