### PR TITLE
[i18n-ES] Add Spanish translation for guides/overview

### DIFF
--- a/.github/workflows/build_documentation.yaml
+++ b/.github/workflows/build_documentation.yaml
@@ -13,6 +13,6 @@ jobs:
     with:
       commit_sha: ${{ github.sha }}
       package: huggingface_hub
-      languages: cn de fr en hi ko or ta
+      languages: cn de es fr en hi ko or ta
     secrets:
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}

--- a/.github/workflows/build_pr_documentation.yaml
+++ b/.github/workflows/build_pr_documentation.yaml
@@ -14,4 +14,4 @@ jobs:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}
       package: huggingface_hub
-      languages: cn de fr en hi ko or ta
+      languages: cn de es fr en hi ko or ta

--- a/docs/source/es/_toctree.yml
+++ b/docs/source/es/_toctree.yml
@@ -1,0 +1,4 @@
+- title: "Guías prácticas"
+  sections:
+    - local: guides/overview
+      title: Descripción general

--- a/docs/source/es/guides/overview.md
+++ b/docs/source/es/guides/overview.md
@@ -1,0 +1,140 @@
+<!--⚠️ Note that this file is in Markdown but contains specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+-->
+
+# Guías prácticas
+
+En esta sección encontrarás guías prácticas para ayudarte a alcanzar un objetivo concreto.
+Échales un vistazo para aprender a usar huggingface_hub y resolver problemas del mundo real:
+
+<div class="mt-10">
+  <div class="w-full flex flex-col space-y-4 md:space-y-0 md:grid md:grid-cols-3 md:gap-y-4 md:gap-x-5">
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg"
+       href="./repository">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">
+        Repositorio
+      </div><p class="text-gray-700">
+        ¿Cómo crear un repositorio en el Hub? ¿Cómo configurarlo? ¿Cómo interactuar con él?
+      </p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg"
+       href="./download">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">
+        Descargar archivos
+      </div><p class="text-gray-700">
+        ¿Cómo descargar un archivo del Hub? ¿Cómo descargar un repositorio?
+      </p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg"
+       href="./upload">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">
+        Subir archivos
+      </div><p class="text-gray-700">
+        ¿Cómo subir un archivo o una carpeta? ¿Cómo hacer cambios en un repositorio que ya existe en el Hub?
+      </p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg"
+       href="./search">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">
+        Búsqueda
+      </div><p class="text-gray-700">
+        ¿Cómo buscar de forma eficiente entre los más de 200k modelos, datasets y Spaces públicos?
+      </p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg"
+       href="./hf_file_system">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">
+        HfFileSystem
+      </div><p class="text-gray-700">
+        ¿Cómo interactuar con el Hub a través de una interfaz cómoda que imita la interfaz de archivos de Python?
+      </p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg"
+       href="./inference">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">
+        Inferencia
+      </div><p class="text-gray-700">
+        ¿Cómo hacer predicciones con Hugging Face Inference Providers?
+      </p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg"
+       href="./community">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">
+        Pestaña Community
+      </div><p class="text-gray-700">
+        ¿Cómo interactuar con la pestaña Community (discusiones y pull requests)?
+      </p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg"
+       href="./collections">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">
+        Colecciones
+      </div><p class="text-gray-700">
+        ¿Cómo construir colecciones de forma programática?
+      </p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg"
+       href="./manage-cache">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">
+        Caché
+      </div><p class="text-gray-700">
+        ¿Cómo funciona el sistema de caché? ¿Cómo sacarle partido?
+      </p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg"
+       href="./model-cards">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">
+        Model Cards
+      </div><p class="text-gray-700">
+        ¿Cómo crear y compartir Model Cards?
+      </p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg"
+       href="./manage-spaces">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">
+        Gestionar tu Space
+      </div><p class="text-gray-700">
+        ¿Cómo gestionar el hardware y la configuración de tu Space?
+      </p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg"
+       href="./integrations">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">
+        Integrar una librería
+      </div><p class="text-gray-700">
+        ¿Qué significa integrar una librería con el Hub? ¿Y cómo se hace?
+      </p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg"
+       href="./webhooks_server">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">
+        Servidor de webhooks
+      </div><p class="text-gray-700">
+        ¿Cómo crear un servidor para recibir webhooks y desplegarlo como un Space?
+      </p>
+    </a>
+
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg"
+       href="./jobs">
+      <div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">
+        Jobs
+      </div><p class="text-gray-700">
+        ¿Cómo ejecutar y gestionar Jobs de cómputo en la infraestructura de Hugging Face y elegir el hardware?
+      </p>
+    </a>
+
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Spanish docs are still missing from `main`. #4401 already bootstraps Get Started (`index.md`, `quick-start.md`, `installation.md`), so this PR does not repeat those pages.

This adds one How-to guides page so the `es` locale can start building and grow one chapter at a time:

- `docs/source/es/guides/overview.md`
- `docs/source/es/_toctree.yml` (only this chapter, per [TRANSLATING.md](https://github.com/huggingface/huggingface_hub/blob/main/docs/TRANSLATING.md))
- register `es` in the main and PR documentation workflows

Prose is informal and gender-neutral. HTML, relative links, doc-builder syntax, and product names (`Hub`, `Spaces`, `HfFileSystem`, `Model Cards`, `Jobs`, …) stay aligned with the English overview. Linked guide pages are not translated yet; they can land in later PRs, same as Hindi did in #4405.

Part of #2640 and #1700. Reviewers from the issue: @Wauplin @hanouticelina @stevhliu.

If a Spanish-speaking reviewer can skim the wording, that would help a lot. Happy to adjust.

## Verification

- Compared the Spanish page to `docs/source/en/guides/overview.md`: 14 cards, same `href`s, same CSS classes, same line count.
- Parsed the new `_toctree.yml` and both workflow files as YAML.
- `make style` and `make quality` (ruff + generated-file checks + `ty check src`) passed. No Python/runtime changes, so library tests were not rerun.

## Example

After the docs build, the new page should show up under Spanish as the How-to guides landing page, with the same card grid as https://huggingface.co/docs/huggingface_hub/en/guides/overview.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only i18n and CI language list updates; no library or runtime behavior changes.
> 
> **Overview**
> Adds **Spanish (`es`)** to the huggingface_hub doc build by registering `es` in the main and PR documentation GitHub workflows, and introducing the first How-to guides slice for that locale.
> 
> New content includes `docs/source/es/_toctree.yml` (chapter **Guías prácticas** → `guides/overview`) and a Spanish `guides/overview.md` landing page that mirrors the English card grid (same links, markup, and product names). Individual guide pages behind those links are not translated in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7ba61fae725eb7c2a5dfe4f62bc8e882461e55d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->