### PR TITLE
Add `--container-registry-{username,password}`

### DIFF
--- a/docs/source/en/guides/inference_endpoints.md
+++ b/docs/source/en/guides/inference_endpoints.md
@@ -127,6 +127,24 @@ By default the Inference Endpoint is built from a docker image provided by Huggi
 
 The value to pass as `custom_image` is a dictionary containing a url to the docker container and configuration to run it. For more details about it, checkout the [Swagger documentation](https://api.endpoints.huggingface.cloud/#/v2%3A%3Aendpoint/create_endpoint).
 
+For an image hosted in a private container registry, pass `container_registry_username` and, when required by the registry, `container_registry_password`. The credentials are only supported for a plain custom container:
+
+```python
+>>> endpoint = create_inference_endpoint(
+...     # Other endpoint and hardware arguments omitted for brevity.
+...     custom_image={"url": "private.registry.example/my-image:latest", "port": 8080},
+...     container_registry_username="user",
+...     container_registry_password="password",
+... )
+```
+
+The equivalent CLI options are `--container-registry-username` and `--container-registry-password`:
+
+```bash
+hf endpoints deploy my-endpoint ... --custom-image private.registry.example/my-image:latest \
+  --container-registry-username user --container-registry-password password
+```
+
 `custom_image` also accepts the engine-specific container types supported by the API, by keying the dictionary with the engine name (`vLLM`, `vLLMNeuron`, `sGLang`, `tgi`, `tgiNeuron`, `tei`, `llamacpp`, `hfServe`, ...) instead of leaving it flat. Each engine takes the usual container fields (`url`, `port`, `healthRoute`) plus its own tuning options. Any dict without a top-level `url` is forwarded to the API untouched, so engines added to the API later work without upgrading `huggingface_hub`:
 
 ```python

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -1803,6 +1803,8 @@ $ hf endpoints deploy [OPTIONS] NAME
 * `--engine [custom|hf-serve|llamacpp|sglang|tei|tgi|tgi-neuron|vllm|vllm-neuron]`: Managed engine image to run --custom-image with (e.g. 'vllm'). Defaults to an arbitrary container.
 * `--health-route TEXT`: Health check route exposed by the container (e.g. '/health'). Requires --custom-image.
 * `--port INTEGER`: Port the container listens on (e.g. 30000). Requires --custom-image.
+* `--container-registry-username TEXT`: Username used to authenticate with the registry hosting --custom-image.
+* `--container-registry-password TEXT`: Optional password used to authenticate with the registry hosting --custom-image.
 * `--tensor-parallel-size INTEGER`: Number of accelerators to shard a single model copy across (vLLM and SGLang engines only).
 * `--data-parallel-size INTEGER`: Number of model copies to run, one per accelerator (vLLM engine only).
 * `--container-command TEXT`: Override the container entrypoint, as a quoted string split into tokens (e.g. "python -m sglang.launch_server").

--- a/src/huggingface_hub/_inference_endpoints.py
+++ b/src/huggingface_hub/_inference_endpoints.py
@@ -18,7 +18,12 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-def _build_endpoint_image_payload(custom_image: dict) -> dict:
+def _build_endpoint_image_payload(
+    custom_image: dict,
+    *,
+    container_registry_username: str | None = None,
+    container_registry_password: str | None = None,
+) -> dict:
     """Build the `model.image` payload of an Inference Endpoint from a user-provided image dict.
 
     `model.image` is a union keyed by variant (`{"vLLM": {...}}`, `{"custom": {...}}`, ...). Only a flat
@@ -26,9 +31,21 @@ def _build_endpoint_image_payload(custom_image: dict) -> dict:
     one are wrapped in `{"custom": ...}`. Everything else is forwarded as-is, so variants added to the API
     later work without a release.
     """
-    if "url" in custom_image:
-        return {"custom": custom_image}
-    return custom_image
+    image = {"custom": custom_image} if "url" in custom_image else custom_image
+
+    if container_registry_password is not None and container_registry_username is None:
+        raise ValueError("`container_registry_password` requires `container_registry_username`.")
+    if container_registry_username is None:
+        return image
+
+    custom_container = image.get("custom")
+    if not isinstance(custom_container, dict):
+        raise ValueError("Container registry credentials can only be set for a custom container image.")
+
+    credentials = {"username": container_registry_username}
+    if container_registry_password is not None:
+        credentials["password"] = container_registry_password
+    return {**image, "custom": {**custom_container, "credentials": credentials}}
 
 
 # Image variants that declare `tensorParallelSize` / `dataParallelSize`. The API ignores a field a variant doesn't

--- a/src/huggingface_hub/cli/inference_endpoints.py
+++ b/src/huggingface_hub/cli/inference_endpoints.py
@@ -361,6 +361,18 @@ def deploy(
     engine: EngineOpt = None,
     health_route: HealthRouteOpt = None,
     port: PortOpt = None,
+    container_registry_username: Annotated[
+        str | None,
+        Option(
+            help="Username used to authenticate with the registry hosting --custom-image.",
+        ),
+    ] = None,
+    container_registry_password: Annotated[
+        str | None,
+        Option(
+            help="Optional password used to authenticate with the registry hosting --custom-image.",
+        ),
+    ] = None,
     tensor_parallel_size: TensorParallelSizeOpt = None,
     data_parallel_size: DataParallelSizeOpt = None,
     container_command: Annotated[
@@ -406,6 +418,8 @@ def deploy(
         engine=engine,
         health_route=health_route,
         port=port,
+        container_registry_username=container_registry_username,
+        container_registry_password=container_registry_password,
         tensor_parallel_size=tensor_parallel_size,
         data_parallel_size=data_parallel_size,
     )
@@ -419,6 +433,10 @@ def deploy(
         params["type"] = endpoint_type
     if custom_image_dict is not None:
         params["custom_image"] = custom_image_dict
+    if container_registry_username is not None:
+        params["container_registry_username"] = container_registry_username
+    if container_registry_password is not None:
+        params["container_registry_password"] = container_registry_password
     if container_command:
         params["container_command"] = shlex.split(container_command)
     if container_args:
@@ -782,6 +800,8 @@ def _build_custom_image(
     engine: str | None = None,
     health_route: str | None = None,
     port: int | None = None,
+    container_registry_username: str | None = None,
+    container_registry_password: str | None = None,
     tensor_parallel_size: int | None = None,
     data_parallel_size: int | None = None,
 ) -> dict | None:
@@ -798,12 +818,19 @@ def _build_custom_image(
             "--engine": engine,
             "--health-route": health_route,
             "--port": port,
+            "--container-registry-username": container_registry_username,
+            "--container-registry-password": container_registry_password,
             "--tensor-parallel-size": tensor_parallel_size,
             "--data-parallel-size": data_parallel_size,
         }
         if used := [flag for flag, value in image_flags.items() if value is not None]:
             raise CLIError(f"--custom-image is required when using {', '.join(used)}.")
         return None
+
+    if container_registry_password is not None and container_registry_username is None:
+        raise CLIError("--container-registry-password requires --container-registry-username.")
+    if engine is not None and container_registry_username is not None:
+        raise CLIError("Container registry credentials can only be set for a custom container without --engine.")
 
     if engine is None and (tensor_parallel_size is not None or data_parallel_size is not None):
         # Without an engine the config is a plain custom container, whose parallelism fields the API ignores

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -9384,6 +9384,8 @@ class HfApi:
         revision: str | None = None,
         task: str | None = None,
         custom_image: dict | None = None,
+        container_registry_username: str | None = None,
+        container_registry_password: str | None = None,
         container_command: list[str] | None = None,
         container_args: list[str] | None = None,
         env: dict[str, str] | None = None,
@@ -9444,6 +9446,11 @@ class HfApi:
                 `llamacpp`, `hfServe`, ...), which is forwarded as-is, or a flat dict describing a custom
                 container (e.g. `{"url": ..., "port": ...}`), which is sent as `{"custom": ...}` (see examples).
                 Defaults to the Hugging Face managed image.
+            container_registry_username (`str`, *optional*):
+                Username used to authenticate with the registry hosting a custom container image.
+            container_registry_password (`str`, *optional*):
+                Password used to authenticate with the registry hosting a custom container image. Requires
+                `container_registry_username`. Omitted from the API payload when not provided.
             container_command (`list[str]`, *optional*):
                 Override the container entrypoint command (maps to `model.command` in the API payload). Works with
                 both managed engine images (e.g. vLLM, SGLang) and custom images.
@@ -9565,7 +9572,18 @@ class HfApi:
                 FutureWarning,
             )
 
-        image = _build_endpoint_image_payload(custom_image) if custom_image is not None else {"huggingface": {}}
+        if custom_image is None:
+            if container_registry_password is not None and container_registry_username is None:
+                raise ValueError("`container_registry_password` requires `container_registry_username`.")
+            if container_registry_username is not None:
+                raise ValueError("`custom_image` is required when setting container registry credentials.")
+            image = {"huggingface": {}}
+        else:
+            image = _build_endpoint_image_payload(
+                custom_image,
+                container_registry_username=container_registry_username,
+                container_registry_password=container_registry_password,
+            )
 
         payload: dict = {
             "accountId": account_id,

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -9572,6 +9572,7 @@ class HfApi:
                 FutureWarning,
             )
 
+        image: dict[str, Any]
         if custom_image is None:
             if container_registry_password is not None and container_registry_username is None:
                 raise ValueError("`container_registry_password` requires `container_registry_username`.")

--- a/src/huggingface_hub/utils/_xet.py
+++ b/src/huggingface_hub/utils/_xet.py
@@ -5,6 +5,7 @@ import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 import httpx
 
@@ -258,9 +259,9 @@ class XetSessionHolder:
     or ``sigint_abort()`` without the GIL serialising them.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._session = None
+        self._session: Any = None
         self._session_pid: int | None = None
 
     def get(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2681,6 +2681,10 @@ class TestInferenceEndpointsCommands:
                     "/health",
                     "--port",
                     "30000",
+                    "--container-registry-username",
+                    "user",
+                    "--container-registry-password",
+                    "secret",
                     "--container-args",
                     "--tp 8 --reasoning-parser qwen3",
                     "--env",
@@ -2697,6 +2701,8 @@ class TestInferenceEndpointsCommands:
             "port": 30000,
         }
         assert kwargs["container_args"] == ["--tp", "8", "--reasoning-parser", "qwen3"]
+        assert kwargs["container_registry_username"] == "user"
+        assert kwargs["container_registry_password"] == "secret"
         assert "container_command" not in kwargs
         assert kwargs["env"] == {"MODEL_ID": "/repository"}
         assert kwargs["type"] == "authenticated"
@@ -3028,11 +3034,28 @@ def test_build_custom_image_warns_for_engine_without_the_field(engine: str, size
     "custom_image, extra, match",
     [
         (None, {"engine": "vllm", "tensor_parallel_size": 8}, "--custom-image is required"),
+        (None, {"container_registry_username": "user"}, "--custom-image is required"),
+        (
+            IMAGE_URL,
+            {"container_registry_password": "secret"},
+            "--container-registry-password requires --container-registry-username",
+        ),
+        (
+            IMAGE_URL,
+            {"engine": "vllm", "container_registry_username": "user"},
+            "only be set for a custom container without --engine",
+        ),
         # Without an engine key the API ignores the parallelism fields rather than rejecting them, which would
         # deploy an endpoint quietly running on a single accelerator.
         (IMAGE_URL, {"tensor_parallel_size": 8}, "require --engine"),
     ],
-    ids=["flags_without_image", "sizes_without_engine"],
+    ids=[
+        "flags_without_image",
+        "registry_credentials_without_image",
+        "registry_password_without_username",
+        "registry_credentials_with_engine",
+        "sizes_without_engine",
+    ],
 )
 def test_build_custom_image_rejects(custom_image: str | None, extra: dict, match: str) -> None:
     with pytest.raises(CLIError, match=match):

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -4711,16 +4711,37 @@ def test_build_endpoint_image_payload(custom_image: dict, expected_image_payload
 
 
 @pytest.mark.parametrize(
-    "custom_image, expected_image_payload",
+    "custom_image, registry_credentials, expected_image_payload",
     [
-        (None, {"huggingface": {}}),
-        ({"vLLM": {"url": "vllm/vllm-openai:v0.23.0"}}, {"vLLM": {"url": "vllm/vllm-openai:v0.23.0"}}),
+        (None, {}, {"huggingface": {}}),
+        (
+            {"vLLM": {"url": "vllm/vllm-openai:v0.23.0"}},
+            {},
+            {"vLLM": {"url": "vllm/vllm-openai:v0.23.0"}},
+        ),
+        (
+            {"url": "private.registry/image:latest", "port": 8080},
+            {"container_registry_username": "user", "container_registry_password": "secret"},
+            {
+                "custom": {
+                    "url": "private.registry/image:latest",
+                    "port": 8080,
+                    "credentials": {"username": "user", "password": "secret"},
+                }
+            },
+        ),
+        (
+            {"url": "private.registry/image:latest"},
+            {"container_registry_username": "user"},
+            {"custom": {"url": "private.registry/image:latest", "credentials": {"username": "user"}}},
+        ),
     ],
-    ids=["no_custom_image", "custom_image"],
+    ids=["no_custom_image", "custom_image", "registry_credentials", "registry_username_only"],
 )
 def test_create_inference_endpoint_custom_image_payload(
     mocker,
     custom_image: Optional[dict],
+    registry_credentials: dict,
     expected_image_payload: dict,
 ):
     """`custom_image` reaches `model.image`, and defaults to the Hugging Face managed image."""
@@ -4759,10 +4780,48 @@ def test_create_inference_endpoint_custom_image_payload(
         task="text-generation",
         namespace="Wauplin",
         custom_image=custom_image,
+        **registry_credentials,
     )
 
     payload = mock_session.post.call_args[1]["json"]
     assert payload["model"]["image"] == expected_image_payload
+
+
+@pytest.mark.parametrize(
+    "custom_image, registry_credentials, match",
+    [
+        (None, {"container_registry_username": "user"}, "`custom_image` is required"),
+        (
+            {"url": "private.registry/image:latest"},
+            {"container_registry_password": "secret"},
+            "`container_registry_password` requires `container_registry_username`",
+        ),
+        (
+            {"vLLM": {"url": "private.registry/image:latest"}},
+            {"container_registry_username": "user"},
+            "only be set for a custom container",
+        ),
+    ],
+    ids=["credentials_without_image", "password_without_username", "credentials_for_engine"],
+)
+def test_create_inference_endpoint_rejects_invalid_registry_credentials(
+    custom_image: dict | None, registry_credentials: dict, match: str
+):
+    api = HfApi(endpoint=ENDPOINT_STAGING, token=TOKEN)
+    with pytest.raises(ValueError, match=match):
+        api.create_inference_endpoint(
+            name="test-endpoint-custom-img",
+            repository="meta-llama/Llama-2-7b-chat-hf",
+            framework="custom",
+            accelerator="gpu",
+            instance_size="medium",
+            instance_type="nvidia-a10g",
+            region="us-east-1",
+            vendor="aws",
+            namespace="Wauplin",
+            custom_image=custom_image,
+            **registry_credentials,
+        )
 
 
 def test_create_inference_endpoint_container_command_and_args_payload(mocker):


### PR DESCRIPTION
## Description

This PR adds both `--container-registry-username` and `--container-registry-password` as custom containers might live in private registries e.g., a Hugging Face Space or a private AWS ECR, and a `username` and `password` might be required.

> [!NOTE]
> Note that this is just supported for endpoints created with custom containers, and that Inference Endpoints already allows those when creating the endpoint (see screenshot).
> <img width="2672" height="1522" alt="Screenshot 2026-09-10 at 10 13 21" src="https://github.com/user-attachments/assets/dce50593-e676-4c5f-9854-958b1402adcb" />

More information about the API spec at https://api.endpoints.huggingface.cloud/#post-/v2/endpoint/-namespace-

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Registry passwords are accepted and forwarded in endpoint creation payloads; misuse or logging could expose secrets, though scope is limited to custom-container deploy with explicit validation.
> 
> **Overview**
> Adds **private registry authentication** when deploying Inference Endpoints with a **plain custom container** (`custom_image` with a top-level `url`, not managed `--engine` images).
> 
> `create_inference_endpoint` and `hf endpoints deploy` accept optional `container_registry_username` / `container_registry_password` (CLI: `--container-registry-username`, `--container-registry-password`). `_build_endpoint_image_payload` nests them under `model.image.custom.credentials` in the API payload; password is omitted when not provided. **Validation** rejects password without username, credentials without `custom_image`, and credentials combined with engine-keyed images or `--engine`.
> 
> Docs and CLI reference include Python and shell examples. Tests cover payload shaping and CLI/API error cases. `_xet.py` only picks up minor typing annotations unrelated to endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d2f3a88874909c97691678a05e8d9e45664447. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->