### PR TITLE
[Jobs] Scope network groups to the namespace and resource group

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -2118,7 +2118,7 @@ Only users with write access to the Job's namespace are allowed in (the Job crea
 
 ### Network groups
 
-Pass `--network-group <name>` to `hf jobs run` (or `hf jobs uv run`) to let Jobs of the same owner reach each other on every port. Inside each member, `$HF_NETWORK_GROUP_HOSTNAME` resolves to every Job in the group, and `${HF_NETWORK_GROUP_PREFIX}<alias>` to the members that claimed an alias with `--network-alias <alias>`:
+Pass `--network-group <name>` to `hf jobs run` (or `hf jobs uv run`) to let Jobs in the same namespace and resource group reach each other on every port. Inside each member, `$HF_NETWORK_GROUP_HOSTNAME` resolves to every Job in the group, and `${HF_NETWORK_GROUP_PREFIX}<alias>` to the members that claimed an alias with `--network-alias <alias>`:
 
 ```bash
 # Start a server, reachable by the other members of the group as "master"
@@ -2128,7 +2128,7 @@ Pass `--network-group <name>` to `hf jobs run` (or `hf jobs uv run`) to let Jobs
 >>> hf jobs run --detach --network-group train python:3.12 sh -c 'curl --retry 10 --retry-connrefused "http://${HF_NETWORK_GROUP_PREFIX}master:8000/"'
 ```
 
-Members are resolvable before they are ready, so connect with retries.
+Members are resolvable before they are ready, so connect with retries. Group names and aliases are lowercase alphanumerics and dashes, 46 and 34 characters max.
 
 ### UV Scripts (Experimental)
 

--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -374,7 +374,7 @@ Only users with write access to the Job's namespace are allowed in (the Job crea
 
 ## Network groups
 
-Pass `network_group="<name>"` to [`run_job`] (or [`run_uv_job`]) to let Jobs of the same owner reach each other on every port. Inside each member, `HF_NETWORK_GROUP_HOSTNAME` resolves to every Job in the group, and `${HF_NETWORK_GROUP_PREFIX}<alias>` to the members that claimed an alias with `network_aliases=[...]`:
+Pass `network_group="<name>"` to [`run_job`] (or [`run_uv_job`]) to let Jobs in the same namespace and resource group reach each other on every port. Inside each member, `HF_NETWORK_GROUP_HOSTNAME` resolves to every Job in the group, and `${HF_NETWORK_GROUP_PREFIX}<alias>` to the members that claimed an alias with `network_aliases=[...]`:
 
 ```python
 >>> from huggingface_hub import run_job
@@ -391,7 +391,7 @@ Pass `network_group="<name>"` to [`run_job`] (or [`run_uv_job`]) to let Jobs of 
 ... )
 ```
 
-Members are resolvable before they are ready, so connect with retries.
+Members are resolvable before they are ready, so connect with retries. Group names and aliases are lowercase alphanumerics and dashes, 46 and 34 characters max.
 
 ## Configure Job Timeout
 

--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -2505,8 +2505,8 @@ $ hf jobs run [OPTIONS] IMAGE COMMAND...
 * `-d, --detach`: Run the Job in the background and print the Job ID.
 * `--expose INTEGER`: Expose a container port through the jobs proxy. Repeat the flag for multiple ports (e.g. `--expose 8000 --expose 8001`). Each exposed port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--ssh`: Make the job's container reachable over SSH. Connect with `hf jobs ssh <job_id>`. Requires an SSH public key registered on https://huggingface.co/settings/keys.
-* `--network-group TEXT`: Join a network group. Jobs of the same owner sharing a group are placed together and reach each other on every port. Inside each member, `$HF_NETWORK_GROUP_HOSTNAME` resolves to every member. Lowercase alphanumerics and dashes, 46 characters max.
-* `--network-alias TEXT`: Claim an alias in the network group. Members reach the jobs claiming it at `${HF_NETWORK_GROUP_PREFIX}<alias>`. Repeat the flag for several aliases. Requires `--network-group`.
+* `--network-group TEXT`: Join a network group. Jobs in the same namespace and resource group sharing a group are placed together and reach each other on every port. Inside each member, `$HF_NETWORK_GROUP_HOSTNAME` resolves to every member. Lowercase alphanumerics and dashes, 46 characters max.
+* `--network-alias TEXT`: Claim an alias in the network group. Members reach the jobs claiming it at `${HF_NETWORK_GROUP_PREFIX}<alias>`. Repeat the flag for several aliases. Lowercase alphanumerics and dashes, 34 characters max, unique within the job. Requires `--network-group`.
 * `--resource-group-id TEXT`: The ID of the resource group to create the Job in. Used to control access to resources within an organization and for cost attribution/spending-limit features.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.
@@ -2979,8 +2979,8 @@ $ hf jobs uv run [OPTIONS] SCRIPT [SCRIPT_ARGS]...
 * `-d, --detach`: Run the Job in the background and print the Job ID.
 * `--expose INTEGER`: Expose a container port through the jobs proxy. Repeat the flag for multiple ports (e.g. `--expose 8000 --expose 8001`). Each exposed port is reachable on the public jobs domain; access requires an HF token with read access to the job's namespace.
 * `--ssh`: Make the job's container reachable over SSH. Connect with `hf jobs ssh <job_id>`. Requires an SSH public key registered on https://huggingface.co/settings/keys.
-* `--network-group TEXT`: Join a network group. Jobs of the same owner sharing a group are placed together and reach each other on every port. Inside each member, `$HF_NETWORK_GROUP_HOSTNAME` resolves to every member. Lowercase alphanumerics and dashes, 46 characters max.
-* `--network-alias TEXT`: Claim an alias in the network group. Members reach the jobs claiming it at `${HF_NETWORK_GROUP_PREFIX}<alias>`. Repeat the flag for several aliases. Requires `--network-group`.
+* `--network-group TEXT`: Join a network group. Jobs in the same namespace and resource group sharing a group are placed together and reach each other on every port. Inside each member, `$HF_NETWORK_GROUP_HOSTNAME` resolves to every member. Lowercase alphanumerics and dashes, 46 characters max.
+* `--network-alias TEXT`: Claim an alias in the network group. Members reach the jobs claiming it at `${HF_NETWORK_GROUP_PREFIX}<alias>`. Repeat the flag for several aliases. Lowercase alphanumerics and dashes, 34 characters max, unique within the job. Requires `--network-group`.
 * `--resource-group-id TEXT`: The ID of the resource group to create the Job in. Used to control access to resources within an organization and for cost attribution/spending-limit features.
 * `--namespace TEXT`: The namespace where the job will be running. Defaults to the current user's namespace.
 * `--token TEXT`: A User Access Token generated from https://huggingface.co/settings/tokens.

--- a/src/huggingface_hub/cli/jobs.py
+++ b/src/huggingface_hub/cli/jobs.py
@@ -220,7 +220,7 @@ NetworkGroupOpt = Annotated[
     str | None,
     Option(
         "--network-group",
-        help="Join a network group. Jobs of the same owner sharing a group are placed together and reach each other on every port. Inside each member, `$HF_NETWORK_GROUP_HOSTNAME` resolves to every member. Lowercase alphanumerics and dashes, 46 characters max.",
+        help="Join a network group. Jobs in the same namespace and resource group sharing a group are placed together and reach each other on every port. Inside each member, `$HF_NETWORK_GROUP_HOSTNAME` resolves to every member. Lowercase alphanumerics and dashes, 46 characters max.",
     ),
 ]
 
@@ -228,7 +228,7 @@ NetworkAliasOpt = Annotated[
     list[str] | None,
     Option(
         "--network-alias",
-        help="Claim an alias in the network group. Members reach the jobs claiming it at `${HF_NETWORK_GROUP_PREFIX}<alias>`. Repeat the flag for several aliases. Requires `--network-group`.",
+        help="Claim an alias in the network group. Members reach the jobs claiming it at `${HF_NETWORK_GROUP_PREFIX}<alias>`. Repeat the flag for several aliases. Lowercase alphanumerics and dashes, 34 characters max, unique within the job. Requires `--network-group`.",
     ),
 ]
 
@@ -410,8 +410,9 @@ def jobs_run(
         out.hint(f"Use `hf jobs ssh {job.owner.name}/{job.id}` to open an SSH session into the job.")
     if network_group:
         out.hint(
-            f"Joined network group '{network_group}'. Jobs started with `--network-group {network_group}` reach each other "
-            "at `$HF_NETWORK_GROUP_HOSTNAME` (every member) or `${HF_NETWORK_GROUP_PREFIX}<alias>` (members claiming an alias)."
+            f"Joined network group '{network_group}'. Jobs of this namespace and resource group started with "
+            f"`--network-group {network_group}` reach each other at `$HF_NETWORK_GROUP_HOSTNAME` (every member) "
+            "or `${HF_NETWORK_GROUP_PREFIX}<alias>` (members claiming an alias)."
         )
     if detach:
         job_ref = f"{job.owner.name}/{job.id}"
@@ -1009,8 +1010,9 @@ def jobs_uv_run(
         out.hint(f"Use `hf jobs ssh {job.owner.name}/{job.id}` to open an SSH session into the job.")
     if network_group:
         out.hint(
-            f"Joined network group '{network_group}'. Jobs started with `--network-group {network_group}` reach each other "
-            "at `$HF_NETWORK_GROUP_HOSTNAME` (every member) or `${HF_NETWORK_GROUP_PREFIX}<alias>` (members claiming an alias)."
+            f"Joined network group '{network_group}'. Jobs of this namespace and resource group started with "
+            f"`--network-group {network_group}` reach each other at `$HF_NETWORK_GROUP_HOSTNAME` (every member) "
+            "or `${HF_NETWORK_GROUP_PREFIX}<alias>` (members claiming an alias)."
         )
     if detach:
         job_ref = f"{job.owner.name}/{job.id}"

--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -12186,13 +12186,15 @@ class HfApi:
                 (https://huggingface.co/settings/keys). Defaults to False.
 
             network_group (`str`, *optional*):
-                Name of a network group to join. Jobs of the same owner sharing a group are placed together and
-                can reach each other on every port. Inside each member, `HF_NETWORK_GROUP_HOSTNAME` resolves to
-                every member of the group. Lowercase alphanumerics and dashes, 46 characters max.
+                Name of a network group to join. Jobs in the same namespace and resource group sharing a group are
+                placed together and can reach each other on every port. Inside each member,
+                `HF_NETWORK_GROUP_HOSTNAME` resolves to every member of the group. Lowercase alphanumerics and dashes,
+                46 characters max.
 
             network_aliases (`list[str]`, *optional*):
                 Aliases this job claims in its network group. Members reach the jobs claiming an alias at
-                `${HF_NETWORK_GROUP_PREFIX}<alias>`. Several jobs may claim the same alias. Requires `network_group`.
+                `${HF_NETWORK_GROUP_PREFIX}<alias>`. Several jobs may claim the same alias. Lowercase alphanumerics
+                and dashes, 34 characters max, unique within the job. Requires `network_group`.
 
             resource_group_id (`str`, *optional*):
                 The ID of the resource group to create the Job in. Used to control access to resources within an
@@ -12847,13 +12849,15 @@ class HfApi:
                 (https://huggingface.co/settings/keys). Defaults to False.
 
             network_group (`str`, *optional*):
-                Name of a network group to join. Jobs of the same owner sharing a group are placed together and
-                can reach each other on every port. Inside each member, `HF_NETWORK_GROUP_HOSTNAME` resolves to
-                every member of the group. Lowercase alphanumerics and dashes, 46 characters max.
+                Name of a network group to join. Jobs in the same namespace and resource group sharing a group are
+                placed together and can reach each other on every port. Inside each member,
+                `HF_NETWORK_GROUP_HOSTNAME` resolves to every member of the group. Lowercase alphanumerics and dashes,
+                46 characters max.
 
             network_aliases (`list[str]`, *optional*):
                 Aliases this job claims in its network group. Members reach the jobs claiming an alias at
-                `${HF_NETWORK_GROUP_PREFIX}<alias>`. Several jobs may claim the same alias. Requires `network_group`.
+                `${HF_NETWORK_GROUP_PREFIX}<alias>`. Several jobs may claim the same alias. Lowercase alphanumerics
+                and dashes, 34 characters max, unique within the job. Requires `network_group`.
 
             resource_group_id (`str`, *optional*):
                 The ID of the resource group to create the Job in. Used to control access to resources within an


### PR DESCRIPTION
## Summary

Follow-up to #4833. The Hub-side implementation scopes a network group to the job's namespace **and resource group**, not the owner alone: two jobs of one org with the same group name but different resource groups (or one with none) are in different groups. Docs and help text said "same owner".

- "same owner" becomes "same namespace and resource group" in the `--network-group` help, the `network_group` docstrings, the `cli.md` and `jobs.md` guides, and the post-run hint
- `--network-alias` help and `network_aliases` docstrings gain the alias rules the Hub enforces: lowercase alphanumerics and dashes, 34 characters max, unique within the job
- CLI reference regenerated

No behavior change. Hub docs: huggingface/hub-docs#2770.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CLI help text only; no runtime behavior changes in huggingface_hub.
> 
> **Overview**
> Aligns **Jobs network group** documentation and CLI help with Hub behavior: membership is scoped to the job’s **namespace and resource group**, not merely the same owner (so identical group names in different resource groups do not interconnect).
> 
> **`--network-group`** / **`network_group`** wording is updated in the guides, regenerated CLI reference, `hf_api` docstrings, option help, and the post-run hint after `hf jobs run` / `hf jobs uv run`.
> 
> **`--network-alias`** / **`network_aliases`** text now documents Hub validation rules: lowercase alphanumerics and dashes, **34 characters max**, **unique within the job**. Group names remain documented at **46 characters max**.
> 
> No client or API logic changes—docs and user-facing strings only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaaac96fb169e9dc2c310e8d3fb8659319cd4d3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->