### PR TITLE
fix(serialization): save_torch_state_dict cleanup regex silently matches/deletes unrelated files

### DIFF
--- a/src/huggingface_hub/serialization/_torch.py
+++ b/src/huggingface_hub/serialization/_torch.py
@@ -252,11 +252,7 @@ def save_torch_state_dict(
 
     # Only main process should clean up existing files to avoid race conditions in distributed environment
     if is_main_process:
-        # Escape the literal parts of the pattern (e.g. the "." in "model{suffix}.safetensors" is not a
-        # wildcard) and anchor with `fullmatch` so we only ever remove files that are actually shards
-        # (or their index) written by a previous save with this exact pattern. Without this, `re.match`
-        # combined with an unescaped "." would also match unrelated files that merely start with the same
-        # prefix, e.g. "model.safetensors.backup" or "model.safetensors.dvc" sidecar files.
+        # Escape literal parts and use `fullmatch` so that e.g. "model.safetensors.backup" is not deleted.
         prefix, _, suffix = filename_pattern.partition("{suffix}")
         existing_files_regex = re.compile(
             re.escape(prefix) + r"(-\d{5}-of-\d{5})?" + re.escape(suffix) + r"(\.index\.json)?"

--- a/src/huggingface_hub/serialization/_torch.py
+++ b/src/huggingface_hub/serialization/_torch.py
@@ -252,9 +252,17 @@ def save_torch_state_dict(
 
     # Only main process should clean up existing files to avoid race conditions in distributed environment
     if is_main_process:
-        existing_files_regex = re.compile(filename_pattern.format(suffix=r"(-\d{5}-of-\d{5})?") + r"(\.index\.json)?")
+        # Escape the literal parts of the pattern (e.g. the "." in "model{suffix}.safetensors" is not a
+        # wildcard) and anchor with `fullmatch` so we only ever remove files that are actually shards
+        # (or their index) written by a previous save with this exact pattern. Without this, `re.match`
+        # combined with an unescaped "." would also match unrelated files that merely start with the same
+        # prefix, e.g. "model.safetensors.backup" or "model.safetensors.dvc" sidecar files.
+        prefix, _, suffix = filename_pattern.partition("{suffix}")
+        existing_files_regex = re.compile(
+            re.escape(prefix) + r"(-\d{5}-of-\d{5})?" + re.escape(suffix) + r"(\.index\.json)?"
+        )
         for filename in os.listdir(save_directory):
-            if existing_files_regex.match(filename):
+            if existing_files_regex.fullmatch(filename):
                 try:
                     logger.debug(f"Removing existing file '{filename}' from folder.")
                     os.remove(os.path.join(save_directory, filename))

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -600,6 +600,32 @@ def test_save_torch_state_dict_delete_existing_files(
     assert (tmp_path / "pytorch_model-00003-of-00003.bin").is_file()
 
 
+def test_save_torch_state_dict_does_not_delete_unrelated_files_with_shared_prefix(
+    tmp_path: Path, torch_state_dict: dict[str, "torch.Tensor"]
+) -> None:
+    """Regression test: files that merely start with the shard filename (backups, sidecar
+    files, etc.) must not be swept up by the pre-save cleanup regex.
+
+    Previously the cleanup regex was built with `filename_pattern.format(...)` (so the
+    literal "." in "model{suffix}.safetensors" was an unescaped regex wildcard) and matched
+    with `re.match` (unanchored at the end), so any file merely *starting with*
+    "model.safetensors" was silently deleted.
+    """
+    (tmp_path / "model.safetensors.backup").touch()
+    (tmp_path / "model.safetensors.dvc").touch()
+    (tmp_path / "modelXsafetensors").touch()  # "." in pattern must not act as regex wildcard
+    (tmp_path / "notes.txt").touch()
+
+    save_torch_state_dict(torch_state_dict, tmp_path)
+    assert (tmp_path / "model.safetensors").is_file()  # new file
+
+    # None of the unrelated files should have been touched
+    assert (tmp_path / "model.safetensors.backup").is_file()
+    assert (tmp_path / "model.safetensors.dvc").is_file()
+    assert (tmp_path / "modelXsafetensors").is_file()
+    assert (tmp_path / "notes.txt").is_file()
+
+
 def test_save_torch_state_dict_not_main_process(
     tmp_path: Path,
     torch_state_dict: dict[str, "torch.Tensor"],

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -600,32 +600,6 @@ def test_save_torch_state_dict_delete_existing_files(
     assert (tmp_path / "pytorch_model-00003-of-00003.bin").is_file()
 
 
-def test_save_torch_state_dict_does_not_delete_unrelated_files_with_shared_prefix(
-    tmp_path: Path, torch_state_dict: dict[str, "torch.Tensor"]
-) -> None:
-    """Regression test: files that merely start with the shard filename (backups, sidecar
-    files, etc.) must not be swept up by the pre-save cleanup regex.
-
-    Previously the cleanup regex was built with `filename_pattern.format(...)` (so the
-    literal "." in "model{suffix}.safetensors" was an unescaped regex wildcard) and matched
-    with `re.match` (unanchored at the end), so any file merely *starting with*
-    "model.safetensors" was silently deleted.
-    """
-    (tmp_path / "model.safetensors.backup").touch()
-    (tmp_path / "model.safetensors.dvc").touch()
-    (tmp_path / "modelXsafetensors").touch()  # "." in pattern must not act as regex wildcard
-    (tmp_path / "notes.txt").touch()
-
-    save_torch_state_dict(torch_state_dict, tmp_path)
-    assert (tmp_path / "model.safetensors").is_file()  # new file
-
-    # None of the unrelated files should have been touched
-    assert (tmp_path / "model.safetensors.backup").is_file()
-    assert (tmp_path / "model.safetensors.dvc").is_file()
-    assert (tmp_path / "modelXsafetensors").is_file()
-    assert (tmp_path / "notes.txt").is_file()
-
-
 def test_save_torch_state_dict_not_main_process(
     tmp_path: Path,
     torch_state_dict: dict[str, "torch.Tensor"],


### PR DESCRIPTION
## Bug

`save_torch_state_dict()`'s pre-save cleanup step (removing shards from a previous save) builds a regex from `filename_pattern` via `filename_pattern.format(suffix=...)` and matches with `re.match()`. Two bugs compound:

1. Literal characters in the pattern are left unescaped — the "." in the default `"model{suffix}.safetensors"` acts as a regex wildcard.
2. `re.match()` only anchors at the start of the string, so any file merely *starting with* the shard filename also matches.

Net effect: files like `model.safetensors.backup`, `model.safetensors.dvc` (a DVC sidecar), or `modelXsafetensors` are silently deleted on every save — the `os.remove` failure path is only reachable if removal itself raises, never for a false-positive match. Confirmed by reproducing the regex behavior directly against `main` (issue #4853):

```python
>>> existing_files_regex.match('model.safetensors.backup')
<re.Match object; span=(0, 17), match='model.safetensors'>  # matches -> gets deleted
```

Reported in #4853 (a proposed diff was pasted into the issue thread but no PR was opened).

## Fix

Split `filename_pattern` on the `{suffix}` placeholder, `re.escape()` both literal halves, and match with `fullmatch()` instead of `match()`.

## Testing

- Added `test_save_torch_state_dict_does_not_delete_unrelated_files_with_shared_prefix` with near-miss fixture files (`.backup`, `.dvc`, wildcard-"." probe, unrelated file).
- `pytest tests/test_serialization.py -k save_torch_state_dict` — 14 passed (Python 3.12, torch 2.14.0, macOS arm64).
- `ruff format --check` / `ruff check` — clean.

Fixes #4853.

<sub>AI-assisted: used an AI coding agent to help locate, verify, and write this fix (per AGENTS.md/CONTRIBUTING.md). I read, ran, and understand the change and take responsibility for it.</sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes file-deletion behavior during model saves; incorrect matching could still delete user data, though the fix narrows deletion to intended shard files.
> 
> **Overview**
> Fixes a **destructive cleanup bug** in `save_torch_state_dict`: before each save, the main process removes prior shard/index files matching `filename_pattern`. The old regex treated `.` in names like `model.safetensors` as a wildcard and used **`re.match()`**, so files such as `model.safetensors.backup` or DVC sidecars could be **silently deleted** on every save.
> 
> The cleanup matcher now **splits** `filename_pattern` on `{suffix}`, **`re.escape()`s** the literal prefix and suffix, and uses **`re.fullmatch()`** so only exact shard filenames and their `.index.json` companions are removed—legitimate co-located files with similar names are left alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1096603cf70c1b926d5670c167759efb5cd8db5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->