### PR TITLE
Add LambdaQ as an inference provider

### DIFF
--- a/docs/source/en/package_reference/cli.md
+++ b/docs/source/en/package_reference/cli.md
@@ -3182,7 +3182,7 @@ $ hf models list [OPTIONS] [REPO_ID]
 * `--gated / --no-gated`: Filter by gated status. '--gated' for gated only, '--no-gated' for non-gated only.
 * `--apps TEXT`: Filter by app(s) that can run the model, e.g. 'ollama' or 'vllm'.
 * `--num-parameters TEXT`: Filter by parameter count, e.g. 'min:6B,max:128B'.
-* `--inference-provider [baseten|cerebras|cohere|deepinfra|fal-ai|featherless-ai|fireworks-ai|groq|hf-inference|novita|nscale|openai|ovhcloud|publicai|replicate|scaleway|together|wavespeed|zai-org]`: Filter by inference provider(s) serving the model, e.g. 'fireworks-ai'.
+* `--inference-provider [baseten|cerebras|cohere|deepinfra|fal-ai|featherless-ai|fireworks-ai|groq|hf-inference|lambdaq|novita|nscale|openai|ovhcloud|publicai|replicate|scaleway|together|wavespeed|zai-org]`: Filter by inference provider(s) serving the model, e.g. 'fireworks-ai'.
 * `--warm`: Only list models currently served by at least one inference provider.
 * `--sort [created_at|downloads|last_modified|likes|trending_score]`: Sort results.
 * `--limit INTEGER`: Limit the number of results.  [default: 30]

--- a/src/huggingface_hub/inference/_client.py
+++ b/src/huggingface_hub/inference/_client.py
@@ -135,7 +135,7 @@ class InferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"lambdaq"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_generated/_async_client.py
+++ b/src/huggingface_hub/inference/_generated/_async_client.py
@@ -125,7 +125,7 @@ class AsyncInferenceClient:
             Note: for better compatibility with OpenAI's client, `model` has been aliased as `base_url`. Those 2
             arguments are mutually exclusive. If a URL is passed as `model` or `base_url` for chat completion, the `(/v1)/chat/completions` suffix path will be appended to the URL.
         provider (`str`, *optional*):
-            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
+            Name of the provider to use for inference. Can be `"baseten"`, `"cerebras"`, `"cohere"`, `"deepinfra"`, `"fal-ai"`, `"featherless-ai"`, `"fireworks-ai"`, `"groq"`, `"hf-inference"`, `"lambdaq"`, `"novita"`, `"nscale"`, `"openai"`, `"ovhcloud"`, `"publicai"`, `"replicate"`, `"scaleway"`, `"together"`, `"wavespeed"` or `"zai-org"`.
             Defaults to "auto": automatic routing, which defaults to "fastest" provider; you can
             switch to "cheapest" or "preferred" provider order at https://hf.co/settings/inference-providers.
             If model is a URL or `base_url` is passed, then `provider` is not used.

--- a/src/huggingface_hub/inference/_providers/__init__.py
+++ b/src/huggingface_hub/inference/_providers/__init__.py
@@ -34,6 +34,13 @@ from .hf_inference import (
     HFInferenceFeatureExtractionTask,
     HFInferenceTask,
 )
+from .lambdaq import (
+    LambdaQConversationalTask,
+    LambdaQFeatureExtractionTask,
+    LambdaQTextGenerationTask,
+    LambdaQTextToImageTask,
+    LambdaQTextToSpeechTask,
+)
 from .novita import NovitaConversationalTask, NovitaTextGenerationTask, NovitaTextToVideoTask
 from .nscale import NscaleConversationalTask, NscaleTextToImageTask
 from .openai import OpenAIConversationalTask
@@ -79,6 +86,7 @@ PROVIDER_T = Literal[
     "fireworks-ai",
     "groq",
     "hf-inference",
+    "lambdaq",
     "novita",
     "nscale",
     "openai",
@@ -158,6 +166,13 @@ PROVIDERS: dict[PROVIDER_T, dict[str, TaskProviderHelper]] = {
         "translation": HFInferenceTask("translation"),
         "summarization": HFInferenceTask("summarization"),
         "visual-question-answering": HFInferenceBinaryInputTask("visual-question-answering"),
+    },
+    "lambdaq": {
+        "conversational": LambdaQConversationalTask(),
+        "feature-extraction": LambdaQFeatureExtractionTask(),
+        "text-generation": LambdaQTextGenerationTask(),
+        "text-to-image": LambdaQTextToImageTask(),
+        "text-to-speech": LambdaQTextToSpeechTask(),
     },
     "novita": {
         "text-generation": NovitaTextGenerationTask(),

--- a/src/huggingface_hub/inference/_providers/_common.py
+++ b/src/huggingface_hub/inference/_providers/_common.py
@@ -29,6 +29,7 @@ HARDCODED_MODEL_INFERENCE_MAPPING: dict[str, dict[str, InferenceProviderMapping]
     "fireworks-ai": {},
     "groq": {},
     "hf-inference": {},
+    "lambdaq": {},
     "nscale": {},
     "ovhcloud": {},
     "replicate": {},

--- a/src/huggingface_hub/inference/_providers/lambdaq.py
+++ b/src/huggingface_hub/inference/_providers/lambdaq.py
@@ -1,0 +1,126 @@
+import base64
+from typing import Any
+
+from huggingface_hub.hf_api import InferenceProviderMapping
+from huggingface_hub.inference._common import RequestParameters, _as_dict
+
+from ._common import BaseConversationalTask, BaseTextGenerationTask, TaskProviderHelper, filter_none
+
+
+_PROVIDER = "lambdaq"
+_BASE_URL = "https://api.lambdaq.org"
+
+
+class LambdaQConversationalTask(BaseConversationalTask):
+    def __init__(self):
+        super().__init__(provider=_PROVIDER, base_url=_BASE_URL)
+
+
+class LambdaQTextGenerationTask(BaseTextGenerationTask):
+    def __init__(self):
+        super().__init__(provider=_PROVIDER, base_url=_BASE_URL)
+
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: dict, provider_mapping_info: InferenceProviderMapping
+    ) -> dict | None:
+        params = filter_none(parameters.copy())
+        # An OpenAI-shaped completions route ignores `max_new_tokens` rather than rejecting it,
+        # so leaving it untranslated does not fail the request: it generates to the context
+        # limit and bills for every token of it.
+        if "max_new_tokens" in params:
+            params["max_tokens"] = params.pop("max_new_tokens")
+        # `model` is applied last so parameters cannot override the mapped provider model.
+        return {"prompt": inputs, **params, "model": provider_mapping_info.provider_id}
+
+    def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
+        output = _as_dict(response)["choices"][0]
+        return {
+            "generated_text": output["text"],
+            "details": {
+                "finish_reason": output.get("finish_reason"),
+                "seed": output.get("seed"),
+            },
+        }
+
+
+class LambdaQFeatureExtractionTask(TaskProviderHelper):
+    def __init__(self):
+        super().__init__(provider=_PROVIDER, base_url=_BASE_URL, task="feature-extraction")
+
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
+        return "/v1/embeddings"
+
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: dict, provider_mapping_info: InferenceProviderMapping
+    ) -> dict | None:
+        # `model` is applied last so parameters cannot override the mapped provider model.
+        return {
+            "input": inputs,
+            **filter_none(parameters),
+            "model": provider_mapping_info.provider_id,
+        }
+
+    def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
+        return [item["embedding"] for item in _as_dict(response)["data"]]
+
+
+class LambdaQTextToImageTask(TaskProviderHelper):
+    def __init__(self):
+        super().__init__(provider=_PROVIDER, base_url=_BASE_URL, task="text-to-image")
+
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
+        return "/v1/images/generations"
+
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: dict, provider_mapping_info: InferenceProviderMapping
+    ) -> dict | None:
+        params = filter_none(parameters.copy())
+        # The route is OpenAI-shaped, where the output size is one `size` string. A model handed
+        # `width`/`height` instead does not fail: it silently returns its default resolution,
+        # which on a per-image price is a wasted generation.
+        if "width" in params and "height" in params:
+            params["size"] = f"{params.pop('width')}x{params.pop('height')}"
+        # `model` is applied last so parameters cannot override the mapped provider model.
+        return {
+            "prompt": inputs,
+            **params,
+            "model": provider_mapping_info.provider_id,
+        }
+
+    def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
+        image = _as_dict(response)["data"][0]
+        b64_json = image.get("b64_json")
+        if b64_json:
+            return base64.b64decode(b64_json)
+        # Some upstreams hand back a link to the generated image instead of the bytes.
+        url = image.get("url")
+        if url:
+            from huggingface_hub.utils import get_session
+
+            return get_session().get(url).content
+        raise ValueError("Unexpected output format from LambdaQ text-to-image API: no image returned.")
+
+
+class LambdaQTextToSpeechTask(TaskProviderHelper):
+    def __init__(self):
+        super().__init__(provider=_PROVIDER, base_url=_BASE_URL, task="text-to-speech")
+
+    def _prepare_route(self, mapped_model: str, api_key: str) -> str:
+        return "/v1/audio/speech"
+
+    def _prepare_payload_as_dict(
+        self, inputs: Any, parameters: dict, provider_mapping_info: InferenceProviderMapping
+    ) -> dict | None:
+        # `voice` is model-specific and optional; we pass it through and let the API surface a
+        # clear error when a model requires one. `model` is applied last so parameters cannot
+        # override the mapped provider model.
+        return {
+            "input": inputs,
+            **filter_none(parameters),
+            "model": provider_mapping_info.provider_id,
+        }
+
+    def get_response(self, response: bytes | dict, request_params: RequestParameters | None = None) -> Any:
+        if isinstance(response, bytes):
+            return response
+        raise ValueError(f"Expected raw audio bytes for text-to-speech, got {type(response).__name__}.")

--- a/tests/test_inference_providers.py
+++ b/tests/test_inference_providers.py
@@ -45,6 +45,13 @@ from huggingface_hub.inference._providers.hf_inference import (
     HFInferenceFeatureExtractionTask,
     HFInferenceTask,
 )
+from huggingface_hub.inference._providers.lambdaq import (
+    LambdaQConversationalTask,
+    LambdaQFeatureExtractionTask,
+    LambdaQTextGenerationTask,
+    LambdaQTextToImageTask,
+    LambdaQTextToSpeechTask,
+)
 from huggingface_hub.inference._providers.novita import NovitaConversationalTask, NovitaTextGenerationTask
 from huggingface_hub.inference._providers.nscale import NscaleConversationalTask, NscaleTextToImageTask
 from huggingface_hub.inference._providers.openai import OpenAIConversationalTask
@@ -1257,6 +1264,124 @@ class TestHFInferenceProvider:
         assert isinstance(request.data, bytes)
         assert request.headers["authorization"] == "Bearer hf_test_token"
         assert request.headers["content-type"] == "image/jpeg"  # based on filename
+
+
+class TestLambdaQProvider:
+    def _mapping(self, task: str, provider_id: str, hf_model_id: str) -> InferenceProviderMapping:
+        return InferenceProviderMapping(
+            provider="lambdaq",
+            hf_model_id=hf_model_id,
+            providerId=provider_id,
+            task=task,
+            status="live",
+        )
+
+    def test_prepare_route(self):
+        assert LambdaQConversationalTask()._prepare_route("model", "api_key") == "/v1/chat/completions"
+        assert LambdaQTextGenerationTask()._prepare_route("model", "api_key") == "/v1/completions"
+        assert LambdaQFeatureExtractionTask()._prepare_route("model", "api_key") == "/v1/embeddings"
+        assert LambdaQTextToImageTask()._prepare_route("model", "api_key") == "/v1/images/generations"
+        assert LambdaQTextToSpeechTask()._prepare_route("model", "api_key") == "/v1/audio/speech"
+
+    def test_prepare_url(self):
+        helper = LambdaQConversationalTask()
+        assert (
+            helper._prepare_url("hf_token", "deepseek-ai/DeepSeek-V3.2")
+            == "https://router.huggingface.co/lambdaq/v1/chat/completions"
+        )
+        assert (
+            helper._prepare_url("lambdaq_key", "deepseek-ai/DeepSeek-V3.2")
+            == "https://api.lambdaq.org/v1/chat/completions"
+        )
+
+    def test_text_generation_payload(self):
+        # An OpenAI-shaped completions route ignores `max_new_tokens` rather than rejecting it,
+        # so an untranslated one generates to the context limit and is billed for it.
+        payload = LambdaQTextGenerationTask()._prepare_payload_as_dict(
+            "Paris is",
+            {"max_new_tokens": 8, "temperature": 0.0, "top_k": None},
+            self._mapping("text-generation", "deepseek-v3.2", "deepseek-ai/DeepSeek-V3.2"),
+        )
+        assert payload == {
+            "prompt": "Paris is",
+            "max_tokens": 8,
+            "temperature": 0.0,
+            "model": "deepseek-v3.2",
+        }
+
+    def test_text_generation_response(self):
+        response = LambdaQTextGenerationTask().get_response(
+            {"choices": [{"text": " a city of love", "finish_reason": "length"}]}
+        )
+        assert response["generated_text"] == " a city of love"
+        assert response["details"]["finish_reason"] == "length"
+
+    def test_feature_extraction_payload_and_response(self):
+        helper = LambdaQFeatureExtractionTask()
+        payload = helper._prepare_payload_as_dict(
+            ["one", "two"],
+            {},
+            self._mapping("feature-extraction", "embed-1", "vendor/embed-1"),
+        )
+        assert payload == {"input": ["one", "two"], "model": "embed-1"}
+        assert helper.get_response({"data": [{"embedding": [0.1, 0.2]}, {"embedding": [0.3, 0.4]}]}) == [
+            [0.1, 0.2],
+            [0.3, 0.4],
+        ]
+
+    def test_text_to_image_size_conversion(self):
+        # A model handed `width`/`height` does not error: it returns its default resolution.
+        # Images are billed per image, so that is a wasted generation, not a retry.
+        payload = LambdaQTextToImageTask()._prepare_payload_as_dict(
+            "a bee on a sunflower",
+            {"width": 512, "height": 768, "num_inference_steps": 2},
+            self._mapping("text-to-image", "sdxl-turbo", "stabilityai/sdxl-turbo"),
+        )
+        assert payload == {
+            "prompt": "a bee on a sunflower",
+            "size": "512x768",
+            "num_inference_steps": 2,
+            "model": "sdxl-turbo",
+        }
+
+    def test_text_to_image_response(self):
+        helper = LambdaQTextToImageTask()
+        assert (
+            helper.get_response({"data": [{"b64_json": base64.b64encode(b"image_bytes").decode()}]}) == b"image_bytes"
+        )
+        with pytest.raises(ValueError, match="no image returned"):
+            helper.get_response({"data": [{"url": None}]})
+
+    def test_text_to_speech_payload_and_response(self):
+        helper = LambdaQTextToSpeechTask()
+        payload = helper._prepare_payload_as_dict(
+            "hello there",
+            {"voice": "af_bella"},
+            self._mapping("text-to-speech", "kokoro-82m", "hexgrad/Kokoro-82M"),
+        )
+        assert payload == {"input": "hello there", "voice": "af_bella", "model": "kokoro-82m"}
+        assert helper.get_response(b"audio_bytes") == b"audio_bytes"
+        with pytest.raises(ValueError, match="Expected raw audio bytes"):
+            helper.get_response({"not": "bytes"})
+
+    @pytest.mark.parametrize(
+        "helper_cls",
+        [
+            LambdaQTextGenerationTask,
+            LambdaQFeatureExtractionTask,
+            LambdaQTextToImageTask,
+            LambdaQTextToSpeechTask,
+        ],
+    )
+    def test_mapped_model_is_not_overridable(self, helper_cls):
+        # `model` is applied last everywhere for this reason.
+        helper = helper_cls()
+        payload = helper._prepare_payload_as_dict(
+            "input",
+            {"model": "attacker/model"},
+            self._mapping(helper.task, "mapped-id", "vendor/model"),
+        )
+        assert payload["model"] == "mapped-id"
 
 
 class TestNovitaProvider:


### PR DESCRIPTION
Python side of https://github.com/huggingface/huggingface.js/pull/2471, which adds [LambdaQ](https://lambdaq.org) as an inference provider.

`new_provider.md` says to land the JS side first — that PR is open and green, so this one is ready whenever you'd like to sequence it.

## What LambdaQ serves

OpenAI-compatible routes under `https://api.lambdaq.org/v1`, so the helper covers five tasks:

| task | route |
| --- | --- |
| `conversational` | `/v1/chat/completions` |
| `text-generation` | `/v1/completions` |
| `feature-extraction` | `/v1/embeddings` |
| `text-to-image` | `/v1/images/generations` |
| `text-to-speech` | `/v1/audio/speech` |

## Two translations that are not just renaming

Both mirror the JS helper exactly:

- **`text-to-image` sends the output size as one OpenAI `size` string.** A model handed `width`/`height` does not fail: it quietly returns its default resolution. Verified against the live API — the same prompt with `size: "512x512"` returned 512×512, with raw `width`/`height` returned 1024×1024. On a per-image price that is a wasted generation.
- **`text-generation` maps `max_new_tokens` to `max_tokens`.** An OpenAI-shaped completions route ignores the HF name rather than rejecting it, so an untranslated `max_new_tokens` generates to the context limit and is billed for every token of it.

## Testing

12 static tests in `TestLambdaQProvider` covering routes, URLs (both `hf-token` and provider-key), both translations, response parsing for each task, and that a caller-supplied `model` can't override the mapped provider id. `pytest tests/test_inference_providers.py` → **188 passed**; `ruff check` and `ruff format` clean.

The equivalent JS helper was additionally verified end to end through `InferenceClient` against a LambdaQ gateway: chat completion, streaming, text generation, text-to-image (blob and dataUrl) and text-to-speech all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UusuRFZbJQAnbC91DWCdcd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive third-party inference routing; incorrect parameter translation could cause unexpected generation length or image resolution and higher billed usage, though behavior is covered by new tests.
> 
> **Overview**
> Adds **LambdaQ** (`lambdaq`) as a Hub inference provider so `InferenceClient` can route chat, text generation, embeddings, image, and speech tasks through LambdaQ’s OpenAI-compatible API at `https://api.lambdaq.org`.
> 
> Registration updates the provider literal and task map in `inference/_providers`, documents `provider="lambdaq"` on sync/async clients, and includes `lambdaq` in the CLI `--inference-provider` filter. A new `lambdaq.py` module wires five tasks to `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/images/generations`, and `/v1/audio/speech`, with **parameter shaping** for HF callers: `max_new_tokens` → `max_tokens` on completions, and `width`/`height` → OpenAI `size` on image generation. Mapped `model` is always set last so user parameters cannot override the provider mapping.
> 
> `TestLambdaQProvider` adds unit coverage for routes, router vs direct URLs, payloads, responses, and model override behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7c1ac2bcf61ee6537eb08455399a442c6274e26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->