### PR TITLE
fix(jobs): omit image digest from readable default name

### DIFF
--- a/src/huggingface_hub/_jobs_api.py
+++ b/src/huggingface_hub/_jobs_api.py
@@ -549,7 +549,8 @@ def _default_job_name_from_image(image: str, command: list[str]) -> str:
             base = _sanitize_job_name(image[len(prefix) :] or image)
             break
     else:
-        base = _sanitize_job_name(image.rstrip("/").split("/")[-1] or image)  # drop registry host and namespace
+        # Drop registry host, namespace and digest from the readable name only.
+        base = _sanitize_job_name(image.split("@", 1)[0].rstrip("/").split("/")[-1] or image)
     return f"{base}-{_short_invocation_hash([image, *command])}"
 
 

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -1,5 +1,7 @@
+import hashlib
 from unittest.mock import patch
 
+import httpx
 import pytest
 
 from huggingface_hub import HfApi, JobStage
@@ -129,3 +131,41 @@ def test_default_job_name_hash_groups_and_splits_by_command() -> None:
     assert truc != bar
     # ...while the same command yields the same name (groups identical runs).
     assert truc == _default_job_name_from_image("python:3.12", ["foo", "--truc"])
+
+
+@pytest.mark.parametrize("tag", ["", ":3.12"])
+def test_default_job_name_digest_is_only_removed_from_readable_name(tag: str) -> None:
+    command = ["python", "-c", "print(1)"]
+    names = []
+    for digest in ["a" * 64, "b" * 64]:
+        image = f"registry.example/namespace/benchmark-task-image{tag}@sha256:{digest}"
+        name = _default_job_name_from_image(image, command)
+        expected_hash = hashlib.sha256("\x00".join([image, *command]).encode()).hexdigest()[:8]
+        base = "benchmark-task-image" + ("-3-12" if tag else "")
+        assert name == f"{base}-{expected_hash}"
+        assert len(name) < 100
+        names.append(name)
+    assert names[0] != names[1]
+
+
+@pytest.mark.parametrize("explicit_name", [None, "custom-name"])
+@pytest.mark.parametrize("image", ["python:3.12", "registry.example/namespace/task@sha256:" + "a" * 64])
+def test_run_job_name_preserves_image_payload(image: str, explicit_name: str | None) -> None:
+    command = ["echo", "hello"]
+    with patch("huggingface_hub.hf_api.get_session") as session:
+        session.return_value.post.return_value = httpx.Response(
+            200,
+            request=httpx.Request("POST", "https://example.com/jobs"),
+            json={
+                "id": "job-id",
+                "owner": {"id": "1234", "name": "user", "type": "user"},
+                "status": {"stage": "PENDING"},
+            },
+        )
+        HfApi(token=False).run_job(
+            image=image, command=command, flavor="cpu-basic", namespace="namespace", name=explicit_name
+        )
+    payload = session.return_value.post.call_args.kwargs["json"]
+    assert payload["dockerImage"] == image
+    assert payload["command"] == command
+    assert payload["labels"]["name"] == (explicit_name or _default_job_name_from_image(image, command))


### PR DESCRIPTION
Strip the digest only from the readable Docker image basename, preserving the full image reference and invocation hash. Explicit names and tagged-image behavior are unchanged.

Tests: 24 offline Jobs tests passed; `make style` and `make quality` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to default label naming only; API payloads and explicit job names are unchanged.
> 
> **Overview**
> Auto-generated Hub Job names no longer embed the `@sha256:…` digest in the human-readable prefix. **`_default_job_name_from_image`** strips everything after `@` only when building the sanitized basename (registry/namespace behavior is unchanged); the **full image reference** still feeds the short invocation hash, so different digests or commands keep distinct names.
> 
> New tests cover digest-only stripping (with and without tags), hash stability vs digest changes, and **`run_job`** ensuring **`dockerImage`** stays the full reference while **`labels.name`** uses either an explicit name or the updated default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3493b0d86bee92db7c10511c534cec455aa84df6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->