### PR TITLE
[Jobs] Expose the network group on JobInfo

### DIFF
--- a/docs/source/en/guides/jobs.md
+++ b/docs/source/en/guides/jobs.md
@@ -389,6 +389,8 @@ Pass `network_group="<name>"` to [`run_job`] (or [`run_uv_job`]) to let Jobs in 
 ...     command=["sh", "-c", 'curl --retry 10 --retry-connrefused "http://${HF_NETWORK_GROUP_PREFIX}master:8000/"'],
 ...     network_group="train",
 ... )
+>>> server.network
+JobNetwork(group='train', aliases=['master'])
 ```
 
 Members are resolvable before they are ready, so connect with retries. Group names and aliases are lowercase alphanumerics and dashes, 46 and 34 characters max.

--- a/docs/source/en/package_reference/jobs.md
+++ b/docs/source/en/package_reference/jobs.md
@@ -26,6 +26,10 @@ Check the [`HfApi`] documentation page for the reference of methods to manage yo
 
 [[autodoc]] JobOwner
 
+### JobNetwork
+
+[[autodoc]] JobNetwork
+
 
 ### JobStage
 

--- a/src/huggingface_hub/__init__.py
+++ b/src/huggingface_hub/__init__.py
@@ -84,6 +84,7 @@ _SUBMOD_ATTRS = {
         "JobHardwareInfo",
         "JobInfo",
         "JobInitiator",
+        "JobNetwork",
         "JobOwner",
         "JobStage",
         "JobStatus",
@@ -799,6 +800,7 @@ __all__ = [
     "JobHardwareInfo",
     "JobInfo",
     "JobInitiator",
+    "JobNetwork",
     "JobOwner",
     "JobStage",
     "JobStatus",
@@ -1288,6 +1290,7 @@ if TYPE_CHECKING:  # pragma: no cover
         JobHardwareInfo,  # noqa: F401
         JobInfo,  # noqa: F401
         JobInitiator,  # noqa: F401
+        JobNetwork,  # noqa: F401
         JobOwner,  # noqa: F401
         JobStage,  # noqa: F401
         JobStatus,  # noqa: F401

--- a/src/huggingface_hub/_jobs_api.py
+++ b/src/huggingface_hub/_jobs_api.py
@@ -117,6 +117,26 @@ class JobOwner:
 
 
 @dataclass
+class JobNetwork:
+    """
+    Network group a Job joined.
+
+    Args:
+        group (`str`):
+            Name of the network group, as passed to `network_group=`.
+        aliases (`list[str]`):
+            Aliases the Job claims in the group, as passed to `network_aliases=`. Empty when none.
+    """
+
+    group: str
+    aliases: list[str]
+
+    def __init__(self, **kwargs) -> None:
+        self.group = kwargs["group"]
+        self.aliases = kwargs.get("aliases") or []
+
+
+@dataclass
 class JobDurations:
     """
     Timing breakdown for a Job, computed server-side.
@@ -211,6 +231,9 @@ class JobInfo:
             SSH endpoint of the Job, e.g. `"ssh://687fb701029421ae5549d998@ssh.hf.jobs"`. Only present when the Job
             was started with `ssh=True`. Connecting requires write access to the Job's namespace and an SSH public
             key registered on the Hub (https://huggingface.co/settings/keys).
+        network (`JobNetwork` or `None`):
+            Network group the Job joined and the aliases it claims, e.g. `JobNetwork(group="train", aliases=["master"])`.
+            `None` when the Job was started without `network_group=`.
 
     Example:
 
@@ -248,6 +271,7 @@ class JobInfo:
     durations: JobDurations | None
     owner: JobOwner
     initiator: JobInitiator | None
+    network: JobNetwork | None
 
     # Inferred fields
     endpoint: str
@@ -286,6 +310,8 @@ class JobInfo:
         self.initiator = (
             JobInitiator(type=initiator["type"], id=initiator["id"], name=initiator.get("name")) if initiator else None
         )
+        network = kwargs.get("network")
+        self.network = JobNetwork(**network) if network else None
 
         # Inferred fields
         self.endpoint = kwargs.get("endpoint", constants.ENDPOINT)

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -5,6 +5,7 @@ import pytest
 from huggingface_hub import HfApi, JobStage
 from huggingface_hub._jobs_api import (
     JobInfo,
+    JobNetwork,
     _default_job_name_from_image,
     _default_job_name_from_script,
 )
@@ -129,3 +130,22 @@ def test_default_job_name_hash_groups_and_splits_by_command() -> None:
     assert truc != bar
     # ...while the same command yields the same name (groups identical runs).
     assert truc == _default_job_name_from_image("python:3.12", ["foo", "--truc"])
+
+
+@pytest.mark.parametrize(
+    "network, expected",
+    [
+        ({"group": "train", "aliases": ["master"]}, JobNetwork(group="train", aliases=["master"])),
+        # The Hub omits `aliases` when the Job claims none.
+        ({"group": "train"}, JobNetwork(group="train", aliases=[])),
+        (None, None),
+    ],
+)
+def test_job_info_parses_network(network, expected) -> None:
+    job = JobInfo(
+        id="job-id",
+        owner={"id": "1234", "name": "user", "type": "user"},
+        status={"stage": "RUNNING"},
+        network=network,
+    )
+    assert job.network == expected


### PR DESCRIPTION
## Summary

Follow-up to #4833. The Hub returns `network: {group, aliases}` on a job, but `JobInfo` dropped it, so neither `inspect_job` nor `hf jobs inspect` could tell which network group a job joined.

Sorry for the many PR @Wauplin 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API mapping and docs/tests only; no changes to job submission or auth paths.
> 
> **Overview**
> Surfaces Hub job **network membership** on [`JobInfo`](src/huggingface_hub/_jobs_api.py) so `inspect_job`, `list_jobs`, and CLI inspect can see which group a job joined.
> 
> Adds a public **`JobNetwork`** type (`group`, `aliases`) and maps the API’s `network` payload onto **`JobInfo.network`** (including when `aliases` is omitted → empty list). **`JobNetwork`** is exported from `huggingface_hub` and documented in the jobs guide and package reference, with a network-groups example showing `server.network`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08af388fda1a92113dc02020c14ad129ebfc0306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->