### PR TITLE
[Utils] Use stripped string in _parse_with_unit integer conversion

### DIFF
--- a/src/huggingface_hub/utils/_parsing.py
+++ b/src/huggingface_hub/utils/_parsing.py
@@ -59,7 +59,7 @@ def _parse_with_unit(value: str, units: dict[str, int]) -> int:
     if not stripped:
         raise ValueError("Value cannot be empty.")
     try:
-        return int(value)
+        return int(stripped)
     except ValueError:
         pass
 

--- a/tests/test_utils_parsing.py
+++ b/tests/test_utils_parsing.py
@@ -18,6 +18,7 @@ from huggingface_hub.utils._parsing import format_duration, format_timesince, pa
         ("1GB", 1_000_000_000),
         ("2TB", 2_000_000_000_000),
         ("0", 0),
+        (" 10 ", 10),
     ],
 )
 def test_parse_size_valid(value, expected):


### PR DESCRIPTION
Fixes #4866

-> Summary
- Update `_parse_with_unit()` in `src/huggingface_hub/utils/_parsing.py` to use `stripped` instead of `value` when attempting integer conversion.
- Add test case in `tests/test_utils_parsing.py` verifying whitespace-padded plain integer strings (e.g. `" 10 "`).

-> Test Plan
- Ran `pytest tests/test_utils_parsing.py` (52/52 PASSED).
- Verified code formatting with `ruff check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavior fix in shared parsing helper with a focused test; no auth, I/O, or API contract changes beyond accepting trimmed plain integers.
> 
> **Overview**
> Fixes plain-number parsing in **`_parse_with_unit`** so values like `" 10 "` work for **`parse_size`** and **`parse_duration`**.
> 
> The helper already strips input before unit matching, but the fast path called **`int(value)`** on the raw string, which failed when surrounding whitespace was present. It now uses **`int(stripped)`**, matching the rest of the function.
> 
> Adds a **`parse_size`** parametrized case for **`" 10 "`**; spaced forms with units (e.g. **`" 10 K"`**) remain invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d7e4460a638f5296af426547c57b6c17397b06e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->