### PR TITLE
[Http] Fix race in `get_session()` creating multiple clients

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -376,7 +376,8 @@ def get_session() -> httpx.Client:
     global _GLOBAL_CLIENT
     if _GLOBAL_CLIENT is None:
         with _CLIENT_LOCK:
-            _GLOBAL_CLIENT = _GLOBAL_CLIENT_FACTORY()
+            if _GLOBAL_CLIENT is None:
+                _GLOBAL_CLIENT = _GLOBAL_CLIENT_FACTORY()
     return _GLOBAL_CLIENT
 
 

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -262,6 +262,30 @@ class TestConfigureSession:
             for j in range(N):
                 assert clients[i] is clients[j]
 
+    def test_get_session_concurrent_first_call_creates_single_client(self):
+        N = 16
+        created = []
+        barrier = threading.Barrier(N)
+        clients = [None] * N
+
+        def _factory() -> httpx.Client:
+            created.append(None)
+            return httpx.Client()
+
+        def _get_session_in_thread(index: int) -> None:
+            barrier.wait()
+            clients[index] = get_session()
+
+        set_client_factory(_factory)
+        threads = [threading.Thread(target=_get_session_in_thread, args=(index,)) for index in range(N)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+
+        assert len(created) == 1
+        assert all(client is clients[0] for client in clients)
+
 
 class TestOfflineModeSession:
     def test_offline_mode(self):


### PR DESCRIPTION
Fixes #4861.

## Summary
- `get_session()` checked `_GLOBAL_CLIENT is None` before taking the lock but not after, so N threads racing on the first call each created their own client, and only the last one survived as the shared client.
- Add the missing re-check inside the lock so the client is created exactly once.
- Add a regression test: 16 threads released by a barrier on a cold start.

Repro from the issue with a counting factory, main vs this PR:

    threads=16 clients_created=16   # main
    threads=64 clients_created=64
    threads=16 clients_created=1    # this PR
    threads=64 clients_created=1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small concurrency fix in shared HTTP client initialization with a targeted regression test; behavior is unchanged except eliminating duplicate client creation on parallel first access.
> 
> **Overview**
> Fixes a **double-checked locking** gap in `get_session()`: threads could all pass the outer `_GLOBAL_CLIENT is None` check on a cold start, enter the lock one after another, and each invoke `_GLOBAL_CLIENT_FACTORY()` before any assignment was visible—so many `httpx.Client` instances were created even though only the last one was kept as the global singleton.
> 
> The change adds the **second null check inside `_CLIENT_LOCK`** so only the first waiter creates the client; later threads reuse it.
> 
> A regression test runs **16 threads** synchronized with a barrier on first `get_session()` and asserts the counting factory runs **once** and every thread gets the **same** client instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c118ce7ac4b88a133ccd53f6f0d5e40b6b9054af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->