### PR TITLE
[RepoCard] Fix AttributeError when model-index has source: null

### DIFF
--- a/src/huggingface_hub/repocard_data.py
+++ b/src/huggingface_hub/repocard_data.py
@@ -627,8 +627,9 @@ def model_index_to_eval_results(model_index: list[dict[str, Any]]) -> tuple[str,
             dataset_split = result["dataset"].get("split")
             dataset_revision = result["dataset"].get("revision")
             dataset_args = result["dataset"].get("args")
-            source_name = result.get("source", {}).get("name")
-            source_url = result.get("source", {}).get("url")
+            source = result.get("source") or {}
+            source_name = source.get("name")
+            source_url = source.get("url")
 
             for metric in result["metrics"]:
                 metric_type = metric["type"]

--- a/tests/test_repocard_data.py
+++ b/tests/test_repocard_data.py
@@ -176,7 +176,32 @@ class TestModelCardData:
         assert eval_results[2].source_name == "Open LLM Leaderboard"
         assert eval_results[2].source_url == OPEN_LLM_LEADERBOARD_URL
 
+    def test_model_index_to_eval_results_source_null(self):
+        """model-index YAML may have 'source: null' (explicit null, which is valid YAML).
+        result.get("source", {}) returns None in that case (the key exists), so calling
+        .get("name") on None used to raise AttributeError. Verify we gracefully treat
+        an explicit null source the same as a missing source key."""
+        model_index = [
+            {
+                "name": "my-cool-model",
+                "results": [
+                    {
+                        "task": {"type": "image-classification"},
+                        "dataset": {"type": "beans", "name": "Beans"},
+                        "metrics": [{"type": "acc", "value": 0.9}],
+                        "source": None,  # explicit null — valid YAML
+                    }
+                ],
+            }
+        ]
+        model_name, eval_results = model_index_to_eval_results(model_index)
+        assert model_name == "my-cool-model"
+        assert len(eval_results) == 1
+        assert eval_results[0].source_name is None
+        assert eval_results[0].source_url is None
+
     def test_card_data_requires_model_name_for_eval_results(self):
+
         with pytest.raises(ValueError, match="`eval_results` requires `model_name` to be set."):
             ModelCardData(
                 eval_results=[


### PR DESCRIPTION
Fixes #4869

-> summary
- `model_index_to_eval_results` crashes with `AttributeError` when a model-index result has `source: null` (explicit null, valid YAML). `result.get("source", {})` returns `None` when the key exists with a `None` value — the default `{}` is only used when the key is absent entirely.
- Fix: use `result.get("source") or {}` to treat explicit `null` and missing key the same way.
- Add regression test `test_model_index_to_eval_results_source_null` in `tests/test_repocard_data.py`.

-> repro (before fix)
```python
from huggingface_hub.repocard_data import model_index_to_eval_results
model_index_to_eval_results([{"name": "m", "results": [{"task": {"type": "t"}, "dataset": {"type": "d", "name": "D"}, "metrics": [{"type": "acc", "value": 0.9}], "source": None}]}])
# → AttributeError: 'NoneType' object has no attribute 'get'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive change in model-index parsing with a targeted regression test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a crash when parsing model card **model-index** metadata where a result entry has **`source: null`** (valid YAML). Previously, `result.get("source", {})` still returned `None` when the key was present with a null value, so chaining `.get("name")` raised **`AttributeError`** during `model_index_to_eval_results`.
> 
> The parser now normalizes with **`result.get("source") or {}`**, so explicit null and a missing `source` key both yield empty `source_name` / `source_url`. A regression test **`test_model_index_to_eval_results_source_null`** covers this case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 492762b0cac57c49f275932f8e7f30310089c052. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->