### PR TITLE
[CI] De-flake HTTP backoff tests + rerun on more transient hub-ci errors

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -112,7 +112,7 @@ jobs:
         working-directory: ./src # For code coverage to work
         run: |
           source ../.venv/bin/activate
-          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|FileNotFoundError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)'"
+          PYTEST="python -m pytest --cov=./huggingface_hub --cov-report=xml:../coverage.xml --vcr-record=none --reruns 8 --reruns-delay 2 --only-rerun '(OSError|FileNotFoundError|Timeout|ConnectError|RemoteProtocolError|HTTPError.*409|HTTPError.*502|HTTPError.*503|HTTPError.*504|not less than or equal to 0.01)'"
 
           case "${{ matrix.test_name }}" in
 
@@ -213,7 +213,7 @@ jobs:
             "--vcr-record=none",
             "--reruns", "8",
             "--reruns-delay", "2",
-            "--only-rerun", "(OSError|FileNotFoundError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)",
+            "--only-rerun", "(OSError|FileNotFoundError|Timeout|ConnectError|RemoteProtocolError|HTTPError.*409|HTTPError.*502|HTTPError.*503|HTTPError.*504|not less than or equal to 0.01)",
             "../tests"
           )
 

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -51,6 +51,12 @@ class TestHttpBackoff:
         yield
         self.patcher.stop()
 
+    @pytest.fixture
+    def mock_sleep(self) -> Generator[Mock, None, None]:
+        """Patch out `time.sleep` so backoff durations are asserted instead of actually waited for."""
+        with patch("huggingface_hub.utils._http.time.sleep") as mock:
+            yield mock
+
     def test_backoff_no_errors(self) -> None:
         """Test normal usage of `http_backoff`."""
         data_mock = Mock()
@@ -135,26 +141,9 @@ class TestHttpBackoff:
         assert self.mock_request.call_count == 4
         assert response is mock_200
 
-    def test_backoff_sleep_time(self) -> None:
-        """Test `http_backoff` sleep time goes exponential until max limit.
-
-        Since timing between 2 requests is sleep duration + some other stuff, this test
-        can be unstable. However, sleep durations between 10ms and 50ms should be enough
-        to make the approximation that measured durations are the "sleep time" waited by
-        `http_backoff`. If this is not the case, just increase `base_wait_time`,
-        `max_wait_time` and `expected_sleep_times` with bigger values.
-        """
-        sleep_times = []
-
-        def _side_effect_timer() -> Generator[ConnectTimeout, None, None]:
-            t0 = time.time()
-            while True:
-                yield ConnectTimeout("Connection timeout")
-                t1 = time.time()
-                sleep_times.append(round(t1 - t0, 1))
-                t0 = t1
-
-        self.mock_request.side_effect = _side_effect_timer()
+    def test_backoff_sleep_time(self, mock_sleep: Mock) -> None:
+        """Test `http_backoff` sleep time goes exponential until max limit."""
+        self.mock_request.side_effect = ConnectTimeout("Connection timeout")
 
         with pytest.raises(ConnectTimeout):
             http_backoff("GET", URL, base_wait_time=0.1, max_wait_time=0.5, max_retries=5)
@@ -162,34 +151,23 @@ class TestHttpBackoff:
         assert self.mock_request.call_count == 6
 
         # Assert sleep times are exponential until plateau
-        expected_sleep_times = [0.1, 0.2, 0.4, 0.5, 0.5]
-        assert sleep_times == expected_sleep_times
+        assert mock_sleep.call_args_list == [call(0.1), call(0.2), call(0.4), call(0.5), call(0.5)]
 
-    def test_backoff_on_429_uses_ratelimit_header(self) -> None:
+    def test_backoff_on_429_uses_ratelimit_header(self, mock_sleep: Mock) -> None:
         """Test that 429 wait time uses full reset time from ratelimit header."""
-        sleep_times = []
-
-        def _side_effect_timer() -> Generator:
-            t0 = time.time()
-            mock_429 = Mock()
-            mock_429.status_code = 429
-            mock_429.headers = {"ratelimit": '"api";r=0;t=1'}  # Server says wait 1s
-            yield mock_429
-            t1 = time.time()
-            sleep_times.append(round(t1 - t0, 1))
-            t0 = t1
-            mock_200 = Mock()
-            mock_200.status_code = 200
-            yield mock_200
-
-        self.mock_request.side_effect = _side_effect_timer()
+        mock_429 = Mock()
+        mock_429.status_code = 429
+        mock_429.headers = {"ratelimit": '"api";r=0;t=1'}  # Server says wait 1s
+        mock_200 = Mock()
+        mock_200.status_code = 200
+        self.mock_request.side_effect = (mock_429, mock_200)
 
         response = http_backoff(
             "GET", URL, base_wait_time=0.1, max_wait_time=0.5, max_retries=3, retry_on_status_codes=429
         )
 
         assert self.mock_request.call_count == 2
-        assert sleep_times == [2.0]
+        assert mock_sleep.call_args_list == [call(2.0)]  # 1s from the header + 1s margin
         assert response.status_code == 200
 
 


### PR DESCRIPTION
## Summary

Two small CI-flakiness fixes that came out of an investigation of the recent red runs on `main` (see the full write-up in the comment below). Neither of these is *the* main cause — most of the noise is on the hub-ci side — but both are cheap and ours to fix.

- **`tests/test_utils_http.py`: stop asserting on wall-clock time.** `test_backoff_on_429_uses_ratelimit_header` measured the real sleep with `time.time()` and asserted `round(t1 - t0, 1) == 2.0`. On a loaded runner it measures `2.1` and fails — that's exactly what killed `build-ubuntu (3.10, with hf_xet)` in #4854. Both this test and `test_backoff_sleep_time` now patch `time.sleep` and assert the durations that `http_backoff` *asked* for, which is what we actually care about. Bonus: the two tests went from ~4s of real sleeping to instant.

- **`--only-rerun`: cover the transient hub-ci errors we actually see.** The regex had `502` and `504` but not `503`, and 503 is by far the most common transient error in failing runs — one run on 2026-09-08 had **7484** occurrences of `Server error '503 Service Temporarily Unavailable' for url '.../api/repos/create'` and 274 distinct failing tests, none of which were retried. Also added `ConnectError` / `RemoteProtocolError`, which is how the Windows runners report `[WinError 10054] An existing connection was forcibly closed by the remote host` (seen in `test_user_overview`, `test_kernel_info`, `test_repo_list`, `test_get_repo_discussion_pagination`, ...).

```diff
-  --only-rerun '(OSError|FileNotFoundError|Timeout|HTTPError.*409|HTTPError.*502|HTTPError.*504|not less than or equal to 0.01)'
+  --only-rerun '(OSError|FileNotFoundError|Timeout|ConnectError|RemoteProtocolError|HTTPError.*409|HTTPError.*502|HTTPError.*503|HTTPError.*504|not less than or equal to 0.01)'
```

I deliberately did *not* add `500` (that would mask real bugs — see the bucket issue below) nor `AssertionError` (way too broad).

## Before / after locally

```
$ pytest tests/test_utils_http.py -k TestHttpBackoff -q
8 passed in 0.61s      # was ~4.5s, and 1-in-N flaky on `assert [2.1] == [2.0]`

$ pytest tests/test_utils_http.py -q
64 passed in 46.59s
```

Opening as draft: the test change is ready, but I'd like a second opinion on how aggressive the rerun regex should get.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI configuration only; no changes to runtime HTTP or library behavior.
> 
> **Overview**
> Reduces CI flakiness in two places: **pytest reruns** and **`http_backoff` tests**.
> 
> The Ubuntu and Windows workflows widen `--only-rerun` so transient hub-ci failures get retried: **503** responses (in addition to 409/502/504) and **`ConnectError` / `RemoteProtocolError`** (e.g. Windows connection resets). Production library behavior is unchanged.
> 
> In `tests/test_utils_http.py`, exponential backoff and 429 ratelimit tests no longer measure real wall-clock delays. A **`mock_sleep`** fixture patches `huggingface_hub.utils._http.time.sleep`, and assertions check the **sleep durations `http_backoff` requests** (including the 2.0s wait for ratelimit header + margin), which removes timing flakes and avoids ~4s of real sleeping in those tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ec100245a97d33ba135500e61903212b97ec3be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->