### PR TITLE
[Spaces] Fix AttributeError in SpaceRuntime when hardware is null

### DIFF
--- a/src/huggingface_hub/_space_api.py
+++ b/src/huggingface_hub/_space_api.py
@@ -230,8 +230,9 @@ class SpaceRuntime:
 
     def __init__(self, data: dict) -> None:
         self.stage = data["stage"]
-        self.hardware = data.get("hardware", {}).get("current")
-        self.requested_hardware = data.get("hardware", {}).get("requested")
+        hardware_dict = data.get("hardware") or {}
+        self.hardware = hardware_dict.get("current")
+        self.requested_hardware = hardware_dict.get("requested")
         self.sleep_time = data.get("gcTimeout")
         self.storage = data.get("storage")
         self.dev_mode = data.get("devMode", False)

--- a/tests/test_hf_api.py
+++ b/tests/test_hf_api.py
@@ -2304,6 +2304,12 @@ class TestHfApiPublicProduction:
         assert space.author == "HuggingFaceH4"
         assert isinstance(space.runtime, SpaceRuntime)
 
+    def test_space_runtime_hardware_none(self) -> None:
+        runtime = SpaceRuntime({"stage": "BUILDING", "hardware": None})
+        assert runtime.stage == "BUILDING"
+        assert runtime.hardware is None
+        assert runtime.requested_hardware is None
+
     def test_space_info_expand_author(self, api: HfApi):
         # Only the selected field is returned
         space = api.space_info(repo_id="HuggingFaceH4/zephyr-chat", expand=["author"])


### PR DESCRIPTION
## Summary

Fixes an `AttributeError` when initializing `SpaceRuntime` with a server payload where `"hardware"` is `null` (e.g. when a Space is `BUILDING` for the first time or has no assigned hardware).

Fixes #4872

## Changes
- Changed `data.get("hardware", {})` to `data.get("hardware") or {}` in `SpaceRuntime.__init__` so that explicit `None` values default safely to an empty dict.
- Added unit test `test_space_runtime_hardware_none` in `tests/test_hf_api.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive parsing change in Space runtime deserialization with a focused unit test; no auth or API contract changes.
> 
> **Overview**
> Fixes a crash when Hub returns `"hardware": null` on Space runtime payloads (e.g. Spaces in `BUILDING` with no hardware yet). `SpaceRuntime.__init__` now normalizes missing or null `hardware` with `data.get("hardware") or {}` before reading `current` and `requested`, instead of chaining `.get()` on `None` when the key is present but null.
> 
> Adds `test_space_runtime_hardware_none` to assert both hardware fields stay `None` when `hardware` is null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b05dd164641ff732dbd4c8763104235283672355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->