### PR TITLE
[Buckets] Fix file metadata size on redirects

### DIFF
--- a/src/huggingface_hub/hf_api.py
+++ b/src/huggingface_hub/hf_api.py
@@ -14834,10 +14834,13 @@ class HfApi:
             42000
             ```
         """
+        headers = self._build_hf_headers(token=token)
+        headers["Accept-Encoding"] = "identity"  # prevent compression so the size matches the file
+
         response = _httpx_follow_hub_redirects_with_backoff(
             "HEAD",
             f"{self.endpoint}/buckets/{bucket_id}/resolve/{quote(remote_path, safe='')}",
-            headers=self._build_hf_headers(token=token),
+            headers=headers,
             retry_on_errors=True,
         )
 
@@ -14845,7 +14848,9 @@ class HfApi:
         if xet_file_data is None:
             raise ValueError(f"Could not parse xet file data for '{remote_path}' in bucket '{bucket_id}'.")
 
-        size = response.headers.get("Content-Length")
+        size = response.headers.get(constants.HUGGINGFACE_HEADER_X_LINKED_SIZE) or (
+            None if response.is_redirect else response.headers.get("Content-Length")
+        )
         if size is None:
             raise ValueError(f"Could not get size for '{remote_path}' in bucket '{bucket_id}'.")
 


### PR DESCRIPTION
Ran into this while working on another project: `get_bucket_file_metadata(...).size` was returning the size of the 302 redirect body rather than the file itself. Opened a PR since it looks like a small fix.

## Summary

- Prefer `X-Linked-Size` and only fall back to `Content-Length` on non-redirect responses.
- Set `Accept-Encoding: identity`, matching `get_hf_file_metadata`.

For example, this public file was reporting `1195` bytes:

```python
from huggingface_hub import HfApi

metadata = HfApi(token=False).get_bucket_file_metadata(
    "huggingface/paperswithcode-backups",
    "postgres/paperswithcode_hf_20260910_031500.dump",
)
print(metadata.size)
# With this change: 992873798
```

Also checked an existing empty file, which now correctly returns `0`.

Held off on adding tests in case you’d prefer to handle those. Happy to adjust this or close it if you’d rather tackle it directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized metadata HEAD handling change with no auth or data-path changes; behavior aligns with existing hub file metadata logic.
> 
> **Overview**
> **Fixes `get_bucket_file_metadata` returning wrong sizes** when the HEAD request hits a redirect (e.g. ~1KB redirect body instead of the real object size).
> 
> The method now mirrors **`get_hf_file_metadata`**: it sends **`Accept-Encoding: identity`** on the HEAD request and resolves size from **`X-Linked-Size`**, using **`Content-Length` only when the response is not a redirect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7bfb96ddbc6d198a980f8838e0fb361181aee5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->