### PR TITLE
fix(cli): restore progress bars on human format and check tty in auto mode (#4860)

### DIFF
--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -26,6 +26,7 @@ from typing import Any, cast
 
 import click
 
+from huggingface_hub.constants import HF_HUB_DISABLE_PROGRESS_BARS
 from huggingface_hub.errors import ConfirmationError
 from huggingface_hub.utils import (
     ANSI,
@@ -33,6 +34,7 @@ from huggingface_hub.utils import (
     disable_progress_bars,
     enable_progress_bars,
     is_agent,
+    is_terminal,
     tabulate,
 )
 
@@ -70,12 +72,11 @@ class Output:
     def set_mode(self, mode: OutputFormat = OutputFormat.auto) -> None:
         """Override the output mode (called once at startup and again per '--format' flag)."""
         if mode == OutputFormat.auto:
-            is_interactive = bool(getattr(sys.stderr, "isatty", lambda: False)())
-            mode = OutputFormat.agent if (is_agent() and not is_interactive) else OutputFormat.human
+            mode = OutputFormat.agent if (is_agent() and not is_terminal(sys.stderr)) else OutputFormat.human
         self.mode = mode
         if mode != OutputFormat.human:
             disable_progress_bars()
-        else:
+        elif not HF_HUB_DISABLE_PROGRESS_BARS:
             enable_progress_bars()
 
     def set_no_truncate(self, no_truncate: bool) -> None:

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -27,7 +27,14 @@ from typing import Any, cast
 import click
 
 from huggingface_hub.errors import ConfirmationError
-from huggingface_hub.utils import ANSI, StatusLine, disable_progress_bars, is_agent, tabulate
+from huggingface_hub.utils import (
+    ANSI,
+    StatusLine,
+    disable_progress_bars,
+    enable_progress_bars,
+    is_agent,
+    tabulate,
+)
 
 
 class OutputFormat(str, Enum):
@@ -63,10 +70,13 @@ class Output:
     def set_mode(self, mode: OutputFormat = OutputFormat.auto) -> None:
         """Override the output mode (called once at startup and again per '--format' flag)."""
         if mode == OutputFormat.auto:
-            mode = OutputFormat.agent if is_agent() else OutputFormat.human
+            is_interactive = bool(getattr(sys.stderr, "isatty", lambda: False)())
+            mode = OutputFormat.agent if (is_agent() and not is_interactive) else OutputFormat.human
         self.mode = mode
         if mode != OutputFormat.human:
             disable_progress_bars()
+        else:
+            enable_progress_bars()
 
     def set_no_truncate(self, no_truncate: bool) -> None:
         """Toggle off cell truncation for human table output."""

--- a/src/huggingface_hub/utils/__init__.py
+++ b/src/huggingface_hub/utils/__init__.py
@@ -116,7 +116,7 @@ from ._runtime import (
 from ._safetensors import SafetensorsFileMetadata, SafetensorsRepoMetadata, TensorInfo
 from ._subprocess import capture_output, run_interactive_subprocess, run_subprocess
 from ._telemetry import send_telemetry
-from ._terminal import ANSI, StatusLine, select_choice, tabulate
+from ._terminal import ANSI, StatusLine, is_terminal, select_choice, tabulate
 from ._typing import is_jsonable, is_simple_optional_type, unwrap_simple_optional_type
 from ._validators import validate_hf_hub_args, validate_repo_id
 from ._xet import (

--- a/src/huggingface_hub/utils/_terminal.py
+++ b/src/huggingface_hub/utils/_terminal.py
@@ -99,7 +99,7 @@ class ANSI:
 
     @classmethod
     def _format(cls, s: str, code: str) -> str:
-        if os.environ.get("NO_COLOR") or is_agent():
+        if os.environ.get("NO_COLOR") or (is_agent() and not bool(getattr(sys.stderr, "isatty", lambda: False)())):
             # See https://no-color.org/
             return s
         return f"{code}{s}{cls._reset}"

--- a/src/huggingface_hub/utils/_terminal.py
+++ b/src/huggingface_hub/utils/_terminal.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import sys
 from contextlib import contextmanager
+from typing import Any
 
 from ._detect_agent import is_agent
 
@@ -30,11 +31,22 @@ else:
     import tty
 
 
+def is_terminal(stream: Any) -> bool:
+    """Safely check if a stream is an interactive terminal (TTY).
+
+    Returns False if the stream is None, closed, or lacks a functional isatty method.
+    """
+    try:
+        return stream is not None and bool(stream.isatty())
+    except (ValueError, OSError, AttributeError):
+        return False
+
+
 class StatusLine:
     """Minimal TTY status line for sync progress (stderr, single-line overwrite)."""
 
     def __init__(self, enabled: bool = True):
-        self._active = enabled and sys.stderr.isatty()
+        self._active = enabled and is_terminal(sys.stderr)
 
     def update(self, msg: str) -> None:
         if not self._active:
@@ -99,7 +111,7 @@ class ANSI:
 
     @classmethod
     def _format(cls, s: str, code: str) -> str:
-        if os.environ.get("NO_COLOR") or (is_agent() and not bool(getattr(sys.stderr, "isatty", lambda: False)())):
+        if os.environ.get("NO_COLOR") or (is_agent() and not is_terminal(sys.stderr)):
             # See https://no-color.org/
             return s
         return f"{code}{s}{cls._reset}"

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -22,6 +22,7 @@ import pytest
 
 from huggingface_hub.cli._output import Output, OutputFormat, _ascii_safe, _to_header
 from huggingface_hub.errors import ConfirmationError
+from huggingface_hub.utils import are_progress_bars_disabled, enable_progress_bars
 
 
 HUMAN = OutputFormat.human
@@ -84,6 +85,47 @@ def test_auto_resets_after_explicit():
     o.set_mode(QUIET)
     o.set_mode(OutputFormat.auto)
     assert o.mode == HUMAN
+
+
+def test_set_mode_human_reenables_progress_bars():
+    try:
+        o = Output()
+        o.set_mode(OutputFormat.agent)
+        assert are_progress_bars_disabled()
+        o.set_mode(OutputFormat.human)
+        assert not are_progress_bars_disabled()
+    finally:
+        enable_progress_bars()
+
+
+def test_auto_resolves_to_human_in_interactive_terminal_even_if_agent(monkeypatch):
+    monkeypatch.setattr("huggingface_hub.cli._output.is_agent", lambda: True)
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
+    assert Output().mode == HUMAN
+
+
+def test_auto_resolves_to_agent_when_not_interactive(monkeypatch):
+    monkeypatch.setattr("huggingface_hub.cli._output.is_agent", lambda: True)
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: False)
+    assert Output().mode == AGENT
+
+
+def test_explicit_agent_mode_forces_agent_even_if_interactive(monkeypatch):
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
+    o = Output()
+    o.set_mode(OutputFormat.agent)
+    assert o.mode == AGENT
+
+
+def test_explicit_agent_mode_disables_bars_even_in_interactive(monkeypatch):
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
+    try:
+        o = Output()
+        o.set_mode(OutputFormat.agent)
+        assert o.mode == AGENT
+        assert are_progress_bars_disabled()
+    finally:
+        enable_progress_bars()
 
 
 # =============================================================================

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -98,6 +98,17 @@ def test_set_mode_human_reenables_progress_bars():
         enable_progress_bars()
 
 
+def test_set_mode_human_does_not_warn_when_bars_env_disabled(monkeypatch):
+    import warnings
+
+    monkeypatch.setattr("huggingface_hub.cli._output.HF_HUB_DISABLE_PROGRESS_BARS", True)
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        o = Output()
+        o.set_mode(OutputFormat.human)
+        assert len(recorded) == 0
+
+
 def test_auto_resolves_to_human_in_interactive_terminal_even_if_agent(monkeypatch):
     monkeypatch.setattr("huggingface_hub.cli._output.is_agent", lambda: True)
     monkeypatch.setattr(sys.stderr, "isatty", lambda: True)

--- a/tests/test_utils_terminal.py
+++ b/tests/test_utils_terminal.py
@@ -4,10 +4,36 @@ from unittest import mock
 
 import pytest
 
-from huggingface_hub.utils._terminal import ANSI, tabulate
+from huggingface_hub.utils._terminal import ANSI, StatusLine, is_terminal, tabulate
 
 
 class TestCLIUtils:
+    def test_is_terminal(self) -> None:
+        assert is_terminal(None) is False
+
+        class ClosedStream:
+            def isatty(self) -> bool:
+                raise ValueError("I/O operation on closed file.")
+
+        class BrokenStream:
+            def isatty(self) -> bool:
+                raise OSError("Bad file descriptor")
+
+        class TTYStream:
+            def isatty(self) -> bool:
+                return True
+
+        assert is_terminal(ClosedStream()) is False
+        assert is_terminal(BrokenStream()) is False
+        assert is_terminal(TTYStream()) is True
+
+    def test_status_line_headless_safe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "stderr", None)
+        status = StatusLine()
+        assert status._active is False
+        status.update("test")
+        status.done("test")
+
     @mock.patch.dict(os.environ, {}, clear=True)
     def test_ansi_utils(self) -> None:
         """Test `ANSI` works as expected."""

--- a/tests/test_utils_terminal.py
+++ b/tests/test_utils_terminal.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from unittest import mock
 
 import pytest
@@ -29,6 +30,20 @@ class TestCLIUtils:
         assert ANSI.red("this is red") == "this is red"
 
         assert ANSI.gray(ANSI.bold("this is bold and grey")) == "this is bold and grey"
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_ansi_agent_interactive_preserves_color(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test `ANSI` does not suppress color in interactive terminal even if is_agent() is True."""
+        monkeypatch.setattr("huggingface_hub.utils._terminal.is_agent", lambda: True)
+        monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
+        assert ANSI.bold("this is bold") == "\x1b[1mthis is bold\x1b[0m"
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_ansi_agent_non_interactive_suppresses_color(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test `ANSI` suppresses color in non-interactive session when is_agent() is True."""
+        monkeypatch.setattr("huggingface_hub.utils._terminal.is_agent", lambda: True)
+        monkeypatch.setattr(sys.stderr, "isatty", lambda: False)
+        assert ANSI.bold("this is bold") == "this is bold"
 
     def test_tabulate_utility(self) -> None:
         """Test `tabulate` works as expected."""


### PR DESCRIPTION
Fixes #4860

### Description
In `auto` output mode, AI agent detection (e.g. from terminals like Warp setting `TERM_PROGRAM=WarpTerminal` or other environment variables matching the agent harness registry) caused progress bars and ANSI colors to be silently disabled, even when running interactively in a user terminal. Additionally, when switching formats back to `human` via `set_mode(OutputFormat.human)`, progress bars remained disabled because `enable_progress_bars()` was not called.

This PR addresses this with:
1. **Defensive interactive TTY check in `auto` mode**:
   In `Output.set_mode()`, when `mode == OutputFormat.auto`, we check if `sys.stderr` is interactive via `is_interactive = bool(getattr(sys.stderr, "isatty", lambda: False)())`. We only select `OutputFormat.agent` if `is_agent() and not is_interactive`; otherwise, interactive terminals resolve to `OutputFormat.human`.
2. **Progress bar restoration**:
   When `mode == OutputFormat.human`, `enable_progress_bars()` is called to re-enable progress bars if they had previously been disabled.
3. **Interactive terminal color preservation**:
   In `ANSI._format()`, colors are preserved if the terminal is interactive, only suppressing colors for agents in non-interactive environments (`is_agent() and not bool(getattr(sys.stderr, "isatty", lambda: False)())`).
4. Explicit `set_mode(OutputFormat.agent)` still forces `agent` mode regardless of TTY status.

### Reproduction & Verification
- Prior to the fix, running `test_set_mode_human_reenables_progress_bars`, `test_auto_resolves_to_human_in_interactive_terminal_even_if_agent`, and `test_ansi_agent_interactive_preserves_color` failed with progress bars remaining disabled and mode resolving to agent in interactive sessions.
- Added comprehensive regression tests in `tests/test_cli_output.py` and `tests/test_utils_terminal.py`.
- Verified all unit tests pass:
  - `uv run pytest tests/test_cli_output.py` (36 passed)
  - `uv run pytest tests/test_utils_detect_agent.py` (17 passed)
  - `uv run pytest tests/test_utils_terminal.py` (6 passed)
  - `uv run --with ruff ruff check src tests` (clean)
  - `uv run --with ruff ruff format --check src tests` (clean)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI output and TTY detection only; no auth, data handling, or API behavior changes.
> 
> **Overview**
> Fixes **agent auto-detection** treating interactive terminals (e.g. Warp) like headless agent sessions, which turned off progress bars and ANSI styling even for real users.
> 
> **Auto format** now picks `agent` only when `is_agent()` is true **and** `stderr` is not a TTY; interactive sessions stay on **human** mode. Explicit `--format agent` still forces agent mode and disables bars.
> 
> Adds a defensive **`is_terminal()`** helper (used by `Output`, `StatusLine`, and `ANSI`) so `isatty()` on missing/closed streams does not crash. **Human** mode calls **`enable_progress_bars()`** again when switching back (unless `HF_HUB_DISABLE_PROGRESS_BARS` is set). **ANSI** keeps color in interactive terminals even when `is_agent()` is true; colors stay suppressed only for non-interactive agent runs.
> 
> Regression tests cover mode resolution, progress bar toggling, and ANSI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87c0fb80d72bb267ddeda0296533da2db362bfd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->