### PR TITLE
Key the doc build concurrency group on the pull request number

### DIFF
--- a/.github/workflows/build_pr_documentation.yaml
+++ b/.github/workflows/build_pr_documentation.yaml
@@ -4,7 +4,7 @@ on:
   pull_request
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## What does this PR do?

`build_pr_documentation.yaml` keys its concurrency group on `github.head_ref`, which is the head branch name without the fork owner. Two open PRs from different forks whose branches share a name therefore land in the same group, and a push on one cancels the in-flight doc build on the other.

Shared names are common, because many contributors push to their fork's default branch instead of creating one. No two of the 58 currently open PRs here share a head branch name, but 30 of them come from forks, so the collision is reachable, and a doc build takes around 4 minutes, which is the window in which it would cancel a build.

`github.event.pull_request.number` is unique per pull request. This workflow only triggers on `pull_request`, so the `github.run_id` fallback is never reached, but keeping it means that a later trigger would fall back to never cancelling rather than to grouping by branch name.

The template this workflow was copied from carries the same expression, and the same one-liner is proposed there in huggingface/doc-builder#829.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI concurrency change with no runtime or application impact.
> 
> **Overview**
> **Fixes doc build cancellations when unrelated PRs share a branch name** (e.g. multiple forks using `main`).
> 
> The **Build PR Documentation** workflow concurrency group now uses **`github.event.pull_request.number`** instead of **`github.head_ref`**, so only concurrent runs for the *same* PR cancel each other. The **`github.run_id`** fallback is unchanged for non–`pull_request` triggers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebc354af5e67af4b387e91049ed5c14f940bcccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->