### PR TITLE
[CLI] Make --format human override agent auto-detection

### DIFF
--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -66,10 +66,10 @@ class Output:
         if mode == OutputFormat.auto:
             mode = OutputFormat.agent if is_agent() else OutputFormat.human
         self.mode = mode
-        human = mode == OutputFormat.human
-        ANSI.set_enabled(human)
+        is_human = mode == OutputFormat.human
+        ANSI.set_enabled(is_human)
         if constants.HF_HUB_DISABLE_PROGRESS_BARS is None:  # env var has priority
-            if human:
+            if is_human:
                 enable_progress_bars()
             else:
                 disable_progress_bars()

--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -26,8 +26,9 @@ from typing import Any, cast
 
 import click
 
+from huggingface_hub import constants
 from huggingface_hub.errors import ConfirmationError
-from huggingface_hub.utils import ANSI, StatusLine, disable_progress_bars, is_agent, tabulate
+from huggingface_hub.utils import ANSI, StatusLine, disable_progress_bars, enable_progress_bars, is_agent, tabulate
 
 
 class OutputFormat(str, Enum):
@@ -65,8 +66,13 @@ class Output:
         if mode == OutputFormat.auto:
             mode = OutputFormat.agent if is_agent() else OutputFormat.human
         self.mode = mode
-        if mode != OutputFormat.human:
-            disable_progress_bars()
+        human = mode == OutputFormat.human
+        ANSI.set_enabled(human)
+        if constants.HF_HUB_DISABLE_PROGRESS_BARS is None:  # env var has priority
+            if human:
+                enable_progress_bars()
+            else:
+                disable_progress_bars()
 
     def set_no_truncate(self, no_truncate: bool) -> None:
         """Toggle off cell truncation for human table output."""

--- a/src/huggingface_hub/utils/_terminal.py
+++ b/src/huggingface_hub/utils/_terminal.py
@@ -68,6 +68,11 @@ class ANSI:
     _reset = "\u001b[0m"
     _underline = "\u001b[4m"
     _yellow = "\u001b[33m"
+    _enabled: bool | None = None  # None: fall back to agent detection (callers outside the `hf` CLI)
+
+    @classmethod
+    def set_enabled(cls, enabled: bool) -> None:
+        cls._enabled = enabled
 
     @classmethod
     def blue(cls, s: str) -> str:
@@ -99,10 +104,11 @@ class ANSI:
 
     @classmethod
     def _format(cls, s: str, code: str) -> str:
-        if os.environ.get("NO_COLOR") or is_agent():
+        if os.environ.get("NO_COLOR"):
             # See https://no-color.org/
             return s
-        return f"{code}{s}{cls._reset}"
+        enabled = cls._enabled if cls._enabled is not None else not is_agent()
+        return f"{code}{s}{cls._reset}" if enabled else s
 
 
 def select_choice(prompt: str, choices: list[str]) -> int:


### PR DESCRIPTION
Related to #4860.

## Summary

- When a registered harness is detected, `auto` resolves to `agent`. Passing `--format human` restored the layout but not the rest: progress bars were disabled once at import and never re-enabled, and `ANSI` called `is_agent()` directly so colors stayed off.
- `set_mode()` now derives everything from the resolved mode: progress bars on for `human`, off otherwise (unless `HF_HUB_DISABLE_PROGRESS_BARS` is set, which keeps priority), and it tells `ANSI` whether colors are on.
- `ANSI.set_enabled()` is the new toggle. Callers outside the `hf` CLI (login flow, tiny-agents CLI) don't set it and fall back to `is_agent()` as before. `NO_COLOR` still wins.
- Side effect: colors are now off in `json` and `quiet` too, not only `agent`. Seems right for machine-oriented modes.
- User-agent attribution and `hf env` are unchanged and keep using `detect_agent()`.


## Example

In a pty with `TERM_PROGRAM=WarpTerminal`, which is detected as the `warp` harness:

Before, `--format human` gave the human layout but no progress bar and no colors:

```
$ hf download sentence-transformers/all-MiniLM-L6-v2 onnx/model_qint8_arm64.onnx --local-dir /tmp/x --format human
✓ Downloaded
  path: /tmp/x/onnx/model_qint8_arm64.onnx
```

After:

```
$ hf download sentence-transformers/all-MiniLM-L6-v2 onnx/model_qint8_arm64.onnx --local-dir /tmp/x --format human
onnx/model_qint8_arm64.onnx: reconstructing file: 100% 23.0M/23.0M [00:01<00:00, 14.5MB/s]
✓ Downloaded   <- green
  path: /tmp/x/onnx/model_qint8_arm64.onnx
```

Without `--format`, the same command still resolves to agent mode (`path=...`, no bars).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation only; respects existing env overrides and preserves non-CLI ANSI behavior via is_agent() fallback.
> 
> **Overview**
> **`--format human` now fully overrides agent harness detection** for terminal UX, not just layout.
> 
> `Output.set_mode()` ties **ANSI colors** and **progress bars** to the resolved format: **human** turns both on; **agent**, **json**, and **quiet** turn colors off and progress bars off unless `HF_HUB_DISABLE_PROGRESS_BARS` is already set (env still wins).
> 
> `ANSI` gains **`set_enabled()`** and an internal override so the `hf` CLI drives coloring from output mode; other callers keep the previous **`is_agent()`** fallback. **`NO_COLOR`** is unchanged and still disables styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9abfa1946ee991160925aeca620dfe36cb12f71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->