### PR TITLE
Re-enable progress bars when CLI output mode is explicitly human

### DIFF
--- a/src/huggingface_hub/cli/_output.py
+++ b/src/huggingface_hub/cli/_output.py
@@ -27,7 +27,7 @@ from typing import Any, cast
 import click
 
 from huggingface_hub.errors import ConfirmationError
-from huggingface_hub.utils import ANSI, StatusLine, disable_progress_bars, is_agent, tabulate
+from huggingface_hub.utils import ANSI, StatusLine, disable_progress_bars, enable_progress_bars, is_agent, tabulate
 
 
 class OutputFormat(str, Enum):
@@ -67,6 +67,8 @@ class Output:
         self.mode = mode
         if mode != OutputFormat.human:
             disable_progress_bars()
+        else:
+            enable_progress_bars()
 
     def set_no_truncate(self, no_truncate: bool) -> None:
         """Toggle off cell truncation for human table output."""

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -86,6 +86,20 @@ def test_auto_resets_after_explicit():
     assert o.mode == HUMAN
 
 
+def test_explicit_human_reenables_progress_bars():
+    # Global progress-bar state: restore it on teardown so other tests are unaffected.
+    from huggingface_hub.utils import are_progress_bars_disabled, enable_progress_bars
+
+    o = Output()
+    o.set_mode(AGENT)
+    assert are_progress_bars_disabled()
+    try:
+        o.set_mode(HUMAN)
+        assert not are_progress_bars_disabled()
+    finally:
+        enable_progress_bars()
+
+
 # =============================================================================
 # out.result()
 # =============================================================================


### PR DESCRIPTION
Fixes part of huggingface/huggingface_hub#4860.

## Problem

`Output.set_mode()` disables progress bars for any non-human mode but never re-enables them:

```python
def set_mode(self, mode: OutputFormat = OutputFormat.auto) -> None:
    if mode == OutputFormat.auto:
        mode = OutputFormat.agent if is_agent() else OutputFormat.human
    self.mode = mode
    if mode != OutputFormat.human:
        disable_progress_bars()
```

In an agent-detected session (the current `auto` detection flags every Warp terminal, see #4860), the CLI starts with `auto` -> `agent` and progress bars are disabled. A later explicit `hf ... --format human` keeps them off: `set_mode(human)` only changes `self.mode`, it never calls `enable_progress_bars()`.

## Change

- `src/huggingface_hub/cli/_output.py`: `set_mode(human)` now calls `enable_progress_bars()`.
- `tests/test_cli_output.py`: new test asserting `set_mode(AGENT)` disables and `set_mode(HUMAN)` re-enables the global progress-bar state.

This is independent of the auto-detection fix and works without any TTY sniffing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI output-mode change with no auth, data, or API impact; only affects global tqdm/progress-bar visibility.
> 
> **Overview**
> **Fixes progress bars staying off after switching the CLI to human output.** `Output.set_mode()` already called `disable_progress_bars()` for non-human modes (agent, json, quiet) but did not turn them back on when mode became `human`—so a session that started in agent/auto could keep bars disabled even with `hf ... --format human`.
> 
> `set_mode()` now calls **`enable_progress_bars()`** when the resolved mode is human, mirroring the existing disable path. A new test checks agent → human toggles the global progress-bar flag and restores state in teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9e7583b1f3e4219a26f1736c7f2eadd278cbb5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->