### PR TITLE
[Commit] Support duck-typed binary file streams in CommitOperationAdd and improve PartialFileIO

### DIFF
--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -200,14 +200,24 @@ class CommitOperationAdd:
             self.path_or_fileobj = os.path.normpath(os.path.expanduser(self.path_or_fileobj))
             if not os.path.isfile(self.path_or_fileobj):
                 raise ValueError(f"Provided path: '{self.path_or_fileobj}' is not a file on the local file system")
-        elif not isinstance(self.path_or_fileobj, (io.BufferedIOBase, bytes)):
-            # ^^ Inspired from: https://stackoverflow.com/questions/44584829/how-to-determine-if-file-is-opened-in-binary-or-text-mode
-            raise ValueError(
-                "path_or_fileobj must be either an instance of str, bytes or"
-                " io.BufferedIOBase. If you passed a file-like object, make sure it is"
-                " in binary mode."
+        elif not isinstance(self.path_or_fileobj, bytes):
+            is_file_like = (
+                hasattr(self.path_or_fileobj, "read")
+                and hasattr(self.path_or_fileobj, "seek")
+                and hasattr(self.path_or_fileobj, "tell")
             )
-        if isinstance(self.path_or_fileobj, io.BufferedIOBase):
+            is_text = isinstance(self.path_or_fileobj, io.TextIOBase) or (
+                hasattr(self.path_or_fileobj, "mode")
+                and isinstance(self.path_or_fileobj.mode, str)
+                and "b" not in self.path_or_fileobj.mode
+                and not isinstance(self.path_or_fileobj, io.RawIOBase)
+            )
+            if not is_file_like or is_text:
+                raise ValueError(
+                    "path_or_fileobj must be either an instance of str, bytes or"
+                    " a binary file-like object. If you passed a file-like object, make sure it is"
+                    " in binary mode."
+                )
             try:
                 self.path_or_fileobj.tell()
                 self.path_or_fileobj.seek(0, os.SEEK_CUR)

--- a/src/huggingface_hub/_commit_api.py
+++ b/src/huggingface_hub/_commit_api.py
@@ -206,11 +206,12 @@ class CommitOperationAdd:
                 and hasattr(self.path_or_fileobj, "seek")
                 and hasattr(self.path_or_fileobj, "tell")
             )
+            try:
+                mode = getattr(self.path_or_fileobj, "mode", None)
+            except Exception:
+                mode = None
             is_text = isinstance(self.path_or_fileobj, io.TextIOBase) or (
-                hasattr(self.path_or_fileobj, "mode")
-                and isinstance(self.path_or_fileobj.mode, str)
-                and "b" not in self.path_or_fileobj.mode
-                and not isinstance(self.path_or_fileobj, io.RawIOBase)
+                isinstance(mode, str) and "b" not in mode and not isinstance(self.path_or_fileobj, io.RawIOBase)
             )
             if not is_file_like or is_text:
                 raise ValueError(

--- a/src/huggingface_hub/_commit_scheduler.py
+++ b/src/huggingface_hub/_commit_scheduler.py
@@ -302,8 +302,29 @@ class PartialFileIO(BytesIO):
         self._size_limit = min(size_limit, os.fstat(self._file.fileno()).st_size)
 
     def __del__(self) -> None:
-        self._file.close()
-        return super().__del__()
+        if hasattr(self, "_file") and self._file is not None and not self._file.closed:
+            self._file.close()
+
+    def close(self) -> None:
+        """Close the underlying file."""
+        if hasattr(self, "_file") and self._file is not None and not self._file.closed:
+            self._file.close()
+
+    @property
+    def closed(self) -> bool:
+        """Return True if the underlying file is closed."""
+        if hasattr(self, "_file") and self._file is not None:
+            return self._file.closed
+        return True
+
+    def readable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return True
+
+    def writable(self) -> bool:
+        return False
 
     def __repr__(self) -> str:
         return f"<PartialFileIO file_path={self._file_path} size_limit={self._size_limit}>"
@@ -312,7 +333,17 @@ class PartialFileIO(BytesIO):
         return self._size_limit
 
     def __getattribute__(self, name: str):
-        if name.startswith("_") or name in ("read", "tell", "seek", "fileno"):  # only 4 public methods supported
+        if name.startswith("_") or name in (
+            "read",
+            "tell",
+            "seek",
+            "fileno",
+            "close",
+            "closed",
+            "readable",
+            "seekable",
+            "writable",
+        ):
             return super().__getattribute__(name)
         raise NotImplementedError(f"PartialFileIO does not support '{name}'.")
 

--- a/src/huggingface_hub/_commit_scheduler.py
+++ b/src/huggingface_hub/_commit_scheduler.py
@@ -326,6 +326,13 @@ class PartialFileIO(BytesIO):
     def writable(self) -> bool:
         return False
 
+    @property
+    def mode(self) -> str:
+        """Return mode of underlying file."""
+        if hasattr(self, "_file") and self._file is not None and hasattr(self._file, "mode"):
+            return self._file.mode
+        return "rb"
+
     def __repr__(self) -> str:
         return f"<PartialFileIO file_path={self._file_path} size_limit={self._size_limit}>"
 
@@ -343,6 +350,8 @@ class PartialFileIO(BytesIO):
             "readable",
             "seekable",
             "writable",
+            "mode",
+            "name",
         ):
             return super().__getattribute__(name)
         raise NotImplementedError(f"PartialFileIO does not support '{name}'.")

--- a/tests/test_commit_api.py
+++ b/tests/test_commit_api.py
@@ -136,3 +136,23 @@ class TestWarnOnOverwritingOperations:
 
     def test_delete_folder_then_add(self) -> None:
         _warn_on_overwriting_operations([self.delete_folder_a, self.add_file_ab, self.add_file_abc])
+
+
+class TestCommitOperationAddBinaryStreams:
+    def test_spooled_temporary_file(self) -> None:
+        import tempfile
+
+        with tempfile.SpooledTemporaryFile(mode="w+b") as f:
+            f.write(b"content")
+            f.seek(0)
+            op = CommitOperationAdd(path_in_repo="file.txt", path_or_fileobj=f)
+            assert op.upload_info.size == 7
+
+    def test_io_file_io(self, tmp_path) -> None:
+        import io
+
+        file_path = tmp_path / "test.bin"
+        file_path.write_bytes(b"content")
+        with io.FileIO(str(file_path), "r") as f:
+            op = CommitOperationAdd(path_in_repo="file.txt", path_or_fileobj=f)
+            assert op.upload_info.size == 7

--- a/tests/test_commit_scheduler.py
+++ b/tests/test_commit_scheduler.py
@@ -250,6 +250,21 @@ class TestPartialFileIO:
         with pytest.raises(NotImplementedError):
             file.write(b"123")
 
+    def test_partial_file_io_close_and_del_safety(self) -> None:
+        file = PartialFileIO(self.file_path, size_limit=5)
+        assert not file.closed
+        assert file.readable()
+        assert file.seekable()
+        assert not file.writable()
+        file.close()
+        assert file.closed
+
+        import gc
+
+        with pytest.raises(FileNotFoundError):
+            PartialFileIO("non_existent_file.txt", 10)
+        gc.collect()
+
     def test_append_to_file_then_read(self) -> None:
         file = PartialFileIO(self.file_path, size_limit=9)
 


### PR DESCRIPTION
## Summary

Allows `CommitOperationAdd` to work with duck-typed binary file streams (e.g. `tempfile.SpooledTemporaryFile`, `io.FileIO`, `fsspec` file objects) that implement `read()`, `seek()`, and `tell()`, rather than restricting strictly to `io.BufferedIOBase`. Also improves `PartialFileIO` reliability and IO interface compatibility.

Fixes #4880

## Changes
- Updated `CommitOperationAdd.__post_init__` to check for binary file-like capabilities (`read`, `seek`, `tell`) while properly rejecting text-mode streams (`io.TextIOBase` / non-binary modes).
- Added `close()`, `closed`, `readable()`, `seekable()`, `writable()` support to `PartialFileIO` and fixed unsafe attribute access in `PartialFileIO.__del__`.
- Added unit tests in `tests/test_commit_api.py` and `tests/test_commit_scheduler.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized validation and wrapper IO changes on the commit upload path; behavior widens accepted inputs while still rejecting text streams.
> 
> **Overview**
> **Commit uploads** now accept duck-typed **binary** streams (`read` / `seek` / `tell`) in `CommitOperationAdd`, not only `io.BufferedIOBase`—so types like `SpooledTemporaryFile` and `io.FileIO` work. Text-mode or non-seekable streams are still rejected, with updated error text.
> 
> **`PartialFileIO`** (used by scheduled commits) gains a safer destructor, explicit `close()` / `closed`, standard IO capability helpers (`readable`, `seekable`, `writable`, `mode`), so it passes the new validation and behaves more like a real binary stream.
> 
> Tests cover binary stream adds and `PartialFileIO` close/GC behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03e9d20571bf9c68d3d30b725269cfecdba3591a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->