### PR TITLE
[Http] Harden session concurrency against re-entrancy and close races (#4861)

### DIFF
--- a/src/huggingface_hub/utils/_http.py
+++ b/src/huggingface_hub/utils/_http.py
@@ -326,7 +326,7 @@ def default_async_client_factory() -> httpx.AsyncClient:
 CLIENT_FACTORY_T = Callable[[], httpx.Client]
 ASYNC_CLIENT_FACTORY_T = Callable[[], httpx.AsyncClient]
 
-_CLIENT_LOCK = threading.Lock()
+_CLIENT_LOCK = threading.RLock()
 _GLOBAL_CLIENT_FACTORY: CLIENT_FACTORY_T = default_client_factory
 _GLOBAL_ASYNC_CLIENT_FACTORY: ASYNC_CLIENT_FACTORY_T = default_async_client_factory
 _GLOBAL_CLIENT: httpx.Client | None = None
@@ -374,11 +374,14 @@ def get_session() -> httpx.Client:
     Use [`set_client_factory`] to customize the `httpx.Client`.
     """
     global _GLOBAL_CLIENT
-    if _GLOBAL_CLIENT is None:
+    client = _GLOBAL_CLIENT
+    if client is None:
         with _CLIENT_LOCK:
-            if _GLOBAL_CLIENT is None:
-                _GLOBAL_CLIENT = _GLOBAL_CLIENT_FACTORY()
-    return _GLOBAL_CLIENT
+            client = _GLOBAL_CLIENT
+            if client is None:
+                client = _GLOBAL_CLIENT_FACTORY()
+                _GLOBAL_CLIENT = client
+    return client
 
 
 def get_async_session() -> httpx.AsyncClient:
@@ -403,17 +406,18 @@ def close_session() -> None:
     Can be useful if e.g. an SSL certificate has been updated.
     """
     global _GLOBAL_CLIENT
-    client = _GLOBAL_CLIENT
+    with _CLIENT_LOCK:
+        client = _GLOBAL_CLIENT
 
-    # First, set global client to None
-    _GLOBAL_CLIENT = None
+        # First, set global client to None
+        _GLOBAL_CLIENT = None
 
-    # Then, close the clients
-    if client is not None:
-        try:
-            client.close()
-        except Exception as e:
-            logger.warning(f"Error closing client: {e}")
+        # Then, close the clients
+        if client is not None:
+            try:
+                client.close()
+            except Exception as e:
+                logger.warning(f"Error closing client: {e}")
 
 
 atexit.register(close_session)

--- a/tests/test_utils_http.py
+++ b/tests/test_utils_http.py
@@ -26,6 +26,7 @@ from huggingface_hub.utils._http import (
     _parse_repo_info_from_url,
     _parse_retry_after,
     _warn_on_warning_headers,
+    close_session,
     default_client_factory,
     fix_hf_endpoint_in_url,
     get_async_session,
@@ -285,6 +286,52 @@ class TestConfigureSession:
 
         assert len(created) == 1
         assert all(client is clients[0] for client in clients)
+
+    def test_get_session_and_close_session_concurrent(self):
+        """Racing close_session() and get_session() never causes get_session() to return None."""
+        N_GETTERS = 8
+        N_CLOSERS = 4
+        barrier = threading.Barrier(N_GETTERS + N_CLOSERS)
+        stop_event = threading.Event()
+        errors = []
+
+        def _getter():
+            barrier.wait()
+            while not stop_event.is_set():
+                sess = get_session()
+                if sess is None:
+                    errors.append("get_session returned None")
+                    break
+
+        def _closer():
+            barrier.wait()
+            while not stop_event.is_set():
+                close_session()
+
+        threads = [threading.Thread(target=_getter) for _ in range(N_GETTERS)] + [
+            threading.Thread(target=_closer) for _ in range(N_CLOSERS)
+        ]
+        for th in threads:
+            th.start()
+
+        time.sleep(0.5)
+        stop_event.set()
+        for th in threads:
+            th.join()
+
+        assert not errors
+
+    def test_set_client_factory_reentrancy_no_deadlock(self):
+        """set_client_factory acquires _CLIENT_LOCK and calls close_session() which also acquires _CLIENT_LOCK."""
+
+        def _factory() -> httpx.Client:
+            close_session()
+            return httpx.Client()
+
+        set_client_factory(_factory)
+        sess = get_session()
+        assert sess is not None
+        close_session()
 
 
 class TestOfflineModeSession:


### PR DESCRIPTION
Follow-up hardening for #4861.

### Summary
- Change \_CLIENT_LOCK = threading.Lock()\ to \_CLIENT_LOCK = threading.RLock()\ to prevent re-entrant deadlocks when \set_client_factory()\ or callbacks invoke \close_session()\.
- In \get_session()\: assign \client = _GLOBAL_CLIENT\ and return \client\ only after verifying non-None, ensuring racing \close_session()\ cannot cause \get_session()\ to return \None\.
- In \close_session()\: synchronize with \with _CLIENT_LOCK:\ to prevent lost closes and zombie clients created during concurrent invocations.
- Add regression tests in \	ests/test_utils_http.py\ covering concurrent \get_session()\ / \close_session()\ access and \set_client_factory()\ re-entrancy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect threading and fork behavior for the global HTTP client used across the library; incorrect locking could cause deadlocks or connection issues in multi-process or highly concurrent workloads.
> 
> **Overview**
> Hardens the shared `httpx.Client` lifecycle in `_http.py` so concurrent and nested access cannot deadlock or return an invalid session.
> 
> The global mutex is now an **`RLock`**, and **`close_session()`** runs entirely under that lock so it stays consistent with **`set_client_factory()`** (which already holds the lock and calls **`close_session()`**). **`get_session()`** uses a local client reference and double-checked initialization so a racing **`close_session()`** cannot yield **`None`**.
> 
> Post-fork handling no longer calls **`close_session()`** (which could block on a lock held by a parent-only thread). A new **`_after_fork_in_child()`** replaces the lock with a fresh **`RLock`**, clears the inherited client without acquiring the old lock, and closes it when present. Regression tests cover concurrent get/close, factory reentrancy, and fork-style lock recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f125c2cf5c3459cd098d3f2ae26e4cecf543cdb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->