### PR TITLE
[Docs] Fix hf discussions info options that do not exist

### DIFF
--- a/docs/source/en/guides/cli.md
+++ b/docs/source/en/guides/cli.md
@@ -1307,14 +1307,9 @@ To inspect a specific discussion or PR, pass the repo ID and the discussion numb
 >>> hf discussions info username/my-model 5
 ```
 
-By default, only the discussion metadata (title, status, author, etc.) is shown. Add `--comments` to include the full conversation thread, or `--diff` to display the PR diff:
+The output contains the discussion metadata (title, status, author, etc.) together with the full list of conversation events. To display the diff of a pull request, use `hf discussions diff` instead.
 
-```bash
->>> hf discussions info username/my-model 5 --comments
->>> hf discussions info username/my-model 5 --diff
-```
-
-Use `--format json` for machine-readable output, and `--no-color` to strip ANSI colors when piping to other tools.
+Use `--format json` for machine-readable output, and set `NO_COLOR=1` to strip ANSI colors when piping to other tools.
 
 ### Create a discussion or PR
 

--- a/docs/source/en/guides/community.md
+++ b/docs/source/en/guides/community.md
@@ -152,8 +152,8 @@ hf discussions list bigscience/bloom
 # List discussions on a dataset repo
 hf discussions list nebius/SWE-rebench-V2 --type dataset
 
-# Get info for a specific discussion with comments
-hf discussions info bigscience/bloom 2 --comments
+# Get info for a specific discussion, including its comment thread
+hf discussions info bigscience/bloom 2
 
 # Create a new discussion
 hf discussions create username/repo-name --title "Bug report" --body "Description here"


### PR DESCRIPTION
## Summary

- `docs/source/en/guides/cli.md` documents `--comments` and `--diff` on `hf discussions info`, but neither exists. The command only takes `--type`/`--repo-type` and `--token` (`src/huggingface_hub/cli/discussions.py:154`), so copying either line straight out of the guide exits with code 2. `docs/source/en/guides/community.md` carried the same `--comments` example in its bash block.
- The `--comments` line was also wrong about the default. `discussion_info` prints the whole `get_discussion_details` object, so the conversation events are already in the output and there is nothing to opt into. The PR diff has its own subcommand, `hf discussions diff`, already documented a few sections down, so the guide now points there instead.
- `--no-color` is not a flag anywhere in the CLI either. Colour suppression reads the `NO_COLOR` environment variable (`src/huggingface_hub/utils/_terminal.py:102`, see https://no-color.org/), so that sentence now says `NO_COLOR=1`.

What the guide tells you to run today:

```
$ hf discussions info bigscience/bloom 2 --comments
Usage: hf discussions info [OPTIONS] REPO_ID NUM
Try 'hf discussions info --help' for help.

Error: No such option '--comments'.

Available options for 'hf discussions info':
  --type, --repo-type [model|dataset|space] The type of repository (model, dataset, or space).  [default: model]
  --token TEXT                   A User Access Token generated from https://huggingface.co/settings/tokens.
  -h, --help                     Show this message and exit.

$ hf discussions info username/my-model 5 --diff
Error: No such option '--diff'.

$ hf discussions ls bigscience/bloom --no-color
Error: No such option '--no-color'.
```

And the events are there without asking for them:

```
$ HF_TOKEN= hf discussions info bigscience/bloom 2 --format json
{"title": "Updates the BLOOM model card to sync with the updated https://github.com/bigscience-workshop/model_card", "status": "merged", "num": 2, "repo_id": "bigscience/bloom", "repo_type": "model", "author": "meg", "is_pull_request": true, "created_at": "2022-05-25T21:26:41+00:00", "endpoint": "https://huggingface.co", "events": [{"id": "628e9f119202a9acd20d4866", "type": "comment", "created_at": "2022-05-25T21:26:41+00:00", "author": "meg", ...}, {"id": "628e9f12bec8ba3575dbd338", "type": "commit", ...}, {"id": "628ea114312d910ef6f98a37", "type": "status-change", ...}], ...}
```

#3899 fixed a neighbouring batch of stale examples in the same two guides, so this is the same lane rather than a duplicate of it.

Checked with a script that parses every `hf ...` line in `docs/source/en/**.md` and validates it against the live click command tree: the discussions hits are gone, the 5 remaining hits are pre-existing false positives (shell pipes and flags inside quoted `--container-args` values). `grep -n 'no-color\|--comments\|--diff'` over both guides is empty, and `make style` (no regenerated file changed) then `make quality` are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact.
> 
> **Overview**
> **Documentation-only fix** for stale `hf discussions` CLI examples in `cli.md` and `community.md`.
> 
> The guides no longer document **`--comments`** or **`--diff`** on `hf discussions info` (those flags are not implemented). They now state that **`info` already returns metadata plus the full event thread**, and that PR diffs belong on **`hf discussions diff`**. The CLI reference example in `community.md` drops the erroneous `--comments` flag.
> 
> Colorless output is documented as **`NO_COLOR=1`** instead of a non-existent **`--no-color`** flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40fe0cc716fffb4e6138819be10f913b6365a53e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->